### PR TITLE
fix mongo env name error and default options

### DIFF
--- a/pkg/aggregator/v1alpha1/metering_options.go
+++ b/pkg/aggregator/v1alpha1/metering_options.go
@@ -16,7 +16,7 @@ type MeteringOptions struct {
 
 // AddFlags adds flags for ServerRunOptions fields to be specified via FlagSet.
 func (s *MeteringOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.Connection.Secret, "metering-secret", "kube-system/icp-metering-receiver-proxy-secret", ""+
+	fs.StringVar(&s.Connection.Secret, "metering-secret", s.Connection.Secret, ""+
 		"Secret file for metering connection")
 	fs.StringVar(&s.Connection.Host, "metering-host", s.Connection.Host, ""+
 		"Aggregator host Name")

--- a/pkg/aggregator/v1alpha1/search_options.go
+++ b/pkg/aggregator/v1alpha1/search_options.go
@@ -16,7 +16,7 @@ type SearchOptions struct {
 
 // AddFlags adds flags for ServerRunOptions fields to be specified via FlagSet.
 func (s *SearchOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.Connection.Secret, "aggregator-secret", "kube-system/search-search-secrets", ""+
+	fs.StringVar(&s.Connection.Secret, "aggregator-secret", s.Connection.Secret, ""+
 		"Secret file for search aggregator connection")
 	fs.StringVar(&s.Connection.Host, "aggregator-host", s.Connection.Host, ""+
 		"Aggregator host Name")

--- a/pkg/storage/mongo/options.go
+++ b/pkg/storage/mongo/options.go
@@ -50,8 +50,8 @@ func (m *Options) AddFlags(fs *pflag.FlagSet) {
 // NewMongoOptions create mongooptions
 func NewMongoOptions() *Options {
 	options := &Options{
-		MongoUser:         os.Getenv("MONGO_ROOT_USERNAME"),
-		MongoPassword:     os.Getenv("MONGO_ROOT_PASSWORD"),
+		MongoUser:         os.Getenv("MONGO_USERNAME"),
+		MongoPassword:     os.Getenv("MONGO_PASSWORD"),
 		MongoSSLCa:        os.Getenv("MONGO_SSLCA"),
 		MongoSSLCert:      os.Getenv("MONGO_SSLCERT"),
 		MongoSSLKey:       os.Getenv("MONGO_SSLKEY"),


### PR DESCRIPTION
1. fix mongo env name errors.
2. remove metering/search default options.