### PR TITLE
Adding generated inventory crd and sample cr

### DIFF
--- a/deploy/crds/inventory.open-cluster-management.io_baremetalassets_cr.yaml
+++ b/deploy/crds/inventory.open-cluster-management.io_baremetalassets_cr.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worker-0-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+---
+apiVersion: inventory.open-cluster-management.io/v1alpha1
+kind: BareMetalAsset
+metadata:
+  name: baremetalasset-worker-0
+spec:
+  bmc:
+    address: ipmi://192.168.122.1:6233
+    credentialsName: worker-0-bmc-secret
+  bootMACAddress: "00:1B:44:11:3A:B7"
+  hardwareProfile: "hardwareProfile"

--- a/deploy/crds/inventory.open-cluster-management.io_baremetalassets_crd.yaml
+++ b/deploy/crds/inventory.open-cluster-management.io_baremetalassets_crd.yaml
@@ -1,0 +1,147 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: baremetalassets.inventory.open-cluster-management.io
+spec:
+  group: inventory.open-cluster-management.io
+  names:
+    kind: BareMetalAsset
+    listKind: BareMetalAssetList
+    plural: baremetalassets
+    singular: baremetalasset
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: BareMetalAsset is the Schema for the baremetalassets API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BareMetalAssetSpec defines the desired state of BareMetalAsset
+          properties:
+            bmc:
+              description: How do we connect to the BMC?
+              properties:
+                address:
+                  description: Address holds the URL for accessing the controller
+                    on the network.
+                  type: string
+                credentialsName:
+                  description: The name of the secret containing the BMC credentials
+                    (requires keys "username" and "password").
+                  type: string
+              required:
+              - address
+              - credentialsName
+              type: object
+            bootMACAddress:
+              description: Which MAC address will PXE boot? This is optional for some
+                types, but required for libvirt VMs driven by vbmc.
+              pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+              type: string
+            clusterDeployment:
+              description: ClusterDeployment which the asset belongs to.
+              type: object
+            hardwareProfile:
+              description: What is the name of the hardware profile for this host?
+                It should only be necessary to set this when inspection cannot automatically
+                determine the profile.
+              type: string
+            role:
+              description: Role holds the role of the asset
+              enum:
+              - master
+              - worker
+              type: string
+          type: object
+        status:
+          description: BareMetalAssetStatus defines the observed state of BareMetalAsset
+          properties:
+            conditions:
+              description: Conditions describes the state of the BareMetalAsset resource.
+              items:
+                description: Condition represents the state of the operator's reconciliation
+                  functionality.
+                properties:
+                  lastHeartbeatTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: ConditionType is the state of the operator's reconciliation
+                      functionality.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            relatedObjects:
+              description: RelatedObjects is a list of objects created and maintained
+                by this operator. Object references will be added to this list after
+                they have been created AND found in the cluster.
+              items:
+                description: ObjectReference contains enough information to let you
+                  inspect or modify the referred object.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
Though the foundation project isn't strictly based on operator-sdk, the inventory controller is based on the operator-sdk. The inventory CRD was generated locally using `operator-sdk generate crds`. I had to temporarily delete the pkg/apis/mcm and pkg/apis/clusterregistry and fake the directory structure (cmd/manager and build/Dockerfile) to be able to generate the crds. The workflow is not ideal but it's better than maintaining the CRD manually in the interim. The CRD should be generated and updated anytime the object definition changes.
This is useful to keep here so other projects (eg. multicloudhub-operator) that use it can reference it as a source of truth.

Fixes #75 