### PR TITLE
fix vendorized build harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ USE_VENDORIZED_BUILD_HARNESS ?=
 ifndef USE_VENDORIZED_BUILD_HARNESS
 -include $(shell curl -s -H 'Authorization: token ${GITHUB_TOKEN}' -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/open-cluster-management/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)
 else
--include vbh/.build-harness-bootstrap
+-include vbh/.build-harness-vendorized
 endif
 
 default::


### PR DESCRIPTION
fix build-harness to execute `make build` in downstream