### PR TITLE
bug(inventory): baremetal hosts should be online

### DIFF
--- a/pkg/acm-controller/inventory/inventory_controller.go
+++ b/pkg/acm-controller/inventory/inventory_controller.go
@@ -529,6 +529,7 @@ func (r *ReconcileBareMetalAsset) newBareMetalHost(instance *inventoryv1alpha1.B
 			},
 			HardwareProfile: instance.Spec.HardwareProfile,
 			BootMACAddress:  instance.Spec.BootMACAddress,
+			Online:          true,
 		},
 	}
 	return bmh

--- a/pkg/controller/inventory/inventory_controller.go
+++ b/pkg/controller/inventory/inventory_controller.go
@@ -559,6 +559,7 @@ func (r *ReconcileBareMetalAsset) newBareMetalHost(instance *inventoryv1alpha1.B
 			},
 			HardwareProfile: instance.Spec.HardwareProfile,
 			BootMACAddress:  instance.Spec.BootMACAddress,
+			Online:          true,
 		},
 	}
 	return bmh


### PR DESCRIPTION
Update the inventory (old and new) controllers to instantiate
BareMetalHost resources -- to be synced via Hive SyncSet -- with
`online: true`.

Fixes https://github.com/open-cluster-management/backlog/issues/2101