### PR TITLE
Add missing items prop to PBList while empty

### DIFF
--- a/pkg/apis/mcm/v1alpha1/placement.go
+++ b/pkg/apis/mcm/v1alpha1/placement.go
@@ -58,7 +58,7 @@ type PlacementBindingList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// List of Cluster objects.
-	Items []PlacementBinding `json:"items,omitempty" protobuf:"bytes,2,rep,name=items"`
+	Items []PlacementBinding `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +genclient


### PR DESCRIPTION
This missing items prop from PlacementBindingList caused OCP failed to be upgraded.

https://github.com/open-cluster-management/backlog/issues/2383 has a few discussion on this one.