### PR TITLE
remove ns access from dynamic role

### DIFF
--- a/pkg/acm-controller/clusterrole/rbac.go
+++ b/pkg/acm-controller/clusterrole/rbac.go
@@ -20,11 +20,6 @@ func buildAdminRoleRules(clusterName string) []rbacv1.PolicyRule {
 			Resources("managedclusters").
 			Names(clusterName).
 			RuleOrDie(),
-		clusterrbac.NewRule("create", "get", "list", "watch", "update", "patch", "delete").
-			Groups("").
-			Resources("namespaces").
-			Names(clusterName).
-			RuleOrDie(),
 	}
 }
 
@@ -35,10 +30,5 @@ func buildViewRoleRules(clusterName string) []rbacv1.PolicyRule {
 			Groups(managedclusterGroup).
 			Resources("managedclusters").
 			Names(clusterName).RuleOrDie(),
-		clusterrbac.NewRule("get", "list", "watch").
-			Groups("").
-			Resources("namespaces").
-			Names(clusterName).
-			RuleOrDie(),
 	}
 }


### PR DESCRIPTION
On verifying the dynamic roles in the latest build, I realized  namespace resource access in the dynamic roles  is not needed here as user still needs admin role on the namespace and also having this access in dynamic roles was causing problem in app/grc  lifecycle i.e app/grc get the user's cluster list based on the namespaces/project user has access to.  


I have also updated the role in design doc 

https://github.com/open-cluster-management/backlog/issues/3175