### PR TITLE
CR to access submariner config in managedcluster-broker ns

### DIFF
--- a/pkg/controllers/clusterset/clustersetmapper/rbac.go
+++ b/pkg/controllers/clusterset/clustersetmapper/rbac.go
@@ -16,6 +16,7 @@ var managedclusterGroup = "cluster.open-cluster-management.io"
 var hiveGroup = "hive.openshift.io"
 var managedClusterViewGroup = "clusterview.open-cluster-management.io"
 var registerGroup = "register.open-cluster-management.io"
+var submarinerGroup = "submariner.io"
 
 // buildAdminRoleRules builds the clustesetadminroles
 func buildAdminRole(clustersetName, clusteroleName string) *rbacv1.ClusterRole {
@@ -56,6 +57,11 @@ func buildAdminRole(clustersetName, clusteroleName string) *rbacv1.ClusterRole {
 			helpers.NewRule("get", "list", "watch").
 				Groups(managedClusterViewGroup).
 				Resources("managedclustersets").
+				RuleOrDie(),
+			helpers.NewRule("create", "get", "update").
+				Groups(submarinerGroup).
+				Resources("brokers").
+				Names(clustersetName).
 				RuleOrDie(),
 		},
 	}


### PR DESCRIPTION
In order to support Globalnet functionality with Submariner addon
some configuration (aka [brokers.submariner.io](https://github.com/submariner-io/submariner-operator/blob/8da203e573e6466830412909d14d21f62d5a5017/api/submariner/v1alpha1/submariner_types.go#L192) object) needs to be
stored in the managedclusterset-broker namespace. This configuration
is clusterSet wide and will be used by submariner-addon code when new
ManagedClusters are added to the ManagedClusterSet.

Currently, the clusterRole assigned to the ManagedClusterSet administrator
(i.e., open-cluster-management:managedclusterset:admin:\<clusterSetName\>)
does not allow creation of the brokers.submariner.io object in the
broker namespace. This PR includes the corresponding role.

Related to: https://github.com/stolostron/backlog/issues/19293

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>