### PR TITLE
fix no route in ocp 311 and errors in log

### DIFF
--- a/pkg/addon/manifests/chart/templates/deployment.yaml
+++ b/pkg/addon/manifests/chart/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- if eq .Values.clusterName "local-cluster" }}
           - "--agent-address={{ template "work-manager.fullname" . }}.{{ .Release.Namespace }}.svc"
           - "--agent-port=443"
-        {{- else if .Values.hasRoute }}
+        {{- else if eq .Values.product "OpenShift" }}
           - "--agent-route={{ .Release.Namespace }}/{{ template "work-manager.fullname" . }}"
         {{- else  }}
           - "--agent-service={{ .Release.Namespace }}/{{ template "work-manager.fullname" . }}"

--- a/pkg/addon/manifests/chart/templates/route.yaml
+++ b/pkg/addon/manifests/chart/templates/route.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if not (eq .Values.clusterName "local-cluster") }}
-{{- if eq .Values.hasRoute true }}
+{{- if eq .Values.product "OpenShift" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/pkg/addon/manifests/chart/templates/service.yaml
+++ b/pkg/addon/manifests/chart/templates/service.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if not (eq .Values.product "") }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,7 +8,7 @@ metadata:
   labels:
     component: "work-manager"
 spec:
-{{- if eq .Values.hasRoute false }}
+{{- if not (eq .Values.product "OpenShift") }}
   type: LoadBalancer
 {{- end }}
   ports:
@@ -17,3 +18,4 @@ spec:
       targetPort: 4443
   selector:
     component: "work-manager"
+{{- end }}

--- a/pkg/addon/manifests/chart/values.yaml
+++ b/pkg/addon/manifests/chart/values.yaml
@@ -8,6 +8,7 @@ fullnameOverride: klusterlet-addon-workmgr
 hubKubeConfigSecret: null
 clusterName: null
 
+product: ""
 hasRoute: false
 
 affinity: {}

--- a/pkg/helpers/imageregistry/client.go
+++ b/pkg/helpers/imageregistry/client.go
@@ -17,46 +17,38 @@ import (
 type Interface interface {
 	Cluster(cluster *clusterv1.ManagedCluster) Interface
 	PullSecret() (*corev1.Secret, error)
-	ImageOverride(imageName string) string
+	ImageOverride(imageName string) (string, error)
 }
 
 type Client struct {
-	kubeClient      kubernetes.Interface
-	imageRegistries v1alpha1.ImageRegistries
+	kubeClient kubernetes.Interface
+	cluster    *clusterv1.ManagedCluster
 }
 
 func NewClient(kubeClient kubernetes.Interface) Interface {
 	return &Client{
-		kubeClient:      kubeClient,
-		imageRegistries: v1alpha1.ImageRegistries{},
+		kubeClient: kubeClient,
 	}
 }
 
 func (c *Client) Cluster(cluster *clusterv1.ManagedCluster) Interface {
-	c.imageRegistries = v1alpha1.ImageRegistries{}
-	if cluster == nil {
-		return c
-	}
-	annotations := cluster.GetAnnotations()
-	if len(annotations) == 0 {
-		return c
-	}
-
-	err := json.Unmarshal([]byte(annotations[v1alpha1.ClusterImageRegistriesAnnotation]), &c.imageRegistries)
-	if err != nil {
-		klog.Errorf("failed to unmarshal imageRegistries from annotation. err: %v", err)
-	}
-	return c
+	return &Client{kubeClient: c.kubeClient, cluster: cluster}
 }
 
 func (c *Client) PullSecret() (*corev1.Secret, error) {
-	if c.imageRegistries.PullSecret == "" {
+	imageRegistries, err := c.getImageRegistries()
+	if err != nil {
+		return nil, err
+	}
+
+	if imageRegistries.PullSecret == "" {
 		return nil, nil
 	}
-	segs := strings.Split(c.imageRegistries.PullSecret, ".")
+
+	segs := strings.Split(imageRegistries.PullSecret, ".")
 	if len(segs) != 2 {
 		return nil, fmt.Errorf("wrong pullSecret format %v in the annotation %s",
-			c.imageRegistries.PullSecret, v1alpha1.ClusterImageRegistriesAnnotation)
+			imageRegistries.PullSecret, v1alpha1.ClusterImageRegistriesAnnotation)
 	}
 	namespace := segs[0]
 	pullSecret := segs[1]
@@ -66,19 +58,24 @@ func (c *Client) PullSecret() (*corev1.Secret, error) {
 // ImageOverride is to override the image by image-registries annotation of managedCluster.
 // The source registry will be replaced by the Mirror.
 // The larger index will work if the Sources are the same.
-func (c *Client) ImageOverride(imageName string) string {
-	if len(c.imageRegistries.Registries) == 0 {
-		return imageName
+func (c *Client) ImageOverride(imageName string) (string, error) {
+	imageRegistries, err := c.getImageRegistries()
+	if err != nil {
+		return imageName, err
+	}
+
+	if len(imageRegistries.Registries) == 0 {
+		return imageName, nil
 	}
 	overrideImageName := imageName
-	for i := 0; i < len(c.imageRegistries.Registries); i++ {
-		registry := c.imageRegistries.Registries[i]
+	for i := 0; i < len(imageRegistries.Registries); i++ {
+		registry := imageRegistries.Registries[i]
 		name := imageOverride(registry.Source, registry.Mirror, imageName)
 		if name != imageName {
 			overrideImageName = name
 		}
 	}
-	return overrideImageName
+	return overrideImageName, nil
 }
 
 func imageOverride(source, mirror, imageName string) string {
@@ -101,27 +98,45 @@ func imageOverride(source, mirror, imageName string) string {
 	return fmt.Sprintf("%s%s", mirror, trimSegment)
 }
 
+func (c *Client) getImageRegistries() (v1alpha1.ImageRegistries, error) {
+	imageRegistries := v1alpha1.ImageRegistries{}
+	if c.cluster == nil {
+		return imageRegistries, fmt.Errorf("the managedCluster cannot be nil")
+	}
+	annotations := c.cluster.GetAnnotations()
+	if len(annotations) == 0 {
+		return imageRegistries, nil
+	}
+
+	if _, ok := annotations[v1alpha1.ClusterImageRegistriesAnnotation]; !ok {
+		return imageRegistries, nil
+	}
+
+	err := json.Unmarshal([]byte(annotations[v1alpha1.ClusterImageRegistriesAnnotation]), &imageRegistries)
+	return imageRegistries, err
+}
+
 // OverrideImageByAnnotation is to override the image by image-registries annotation of managedCluster.
 // The source registry will be replaced by the Mirror.
 // The larger index will work if the Sources are the same.
-func OverrideImageByAnnotation(annotations map[string]string, imageName string) string {
+func OverrideImageByAnnotation(annotations map[string]string, imageName string) (string, error) {
 	if len(annotations) == 0 {
-		return imageName
+		return imageName, nil
 	}
 
-	if annotations[v1alpha1.ClusterImageRegistriesAnnotation] == "" {
-		return imageName
+	if _, ok := annotations[v1alpha1.ClusterImageRegistriesAnnotation]; !ok {
+		return imageName, nil
 	}
 
 	imageRegistries := v1alpha1.ImageRegistries{}
 	err := json.Unmarshal([]byte(annotations[v1alpha1.ClusterImageRegistriesAnnotation]), &imageRegistries)
 	if err != nil {
-		klog.Errorf("failed to unmarshal the annotation %v,err %v", v1alpha1.ClusterImageRegistriesAnnotation, err)
-		return imageName
+		klog.Errorf("failed to unmarshal the annotation %v,err %v", annotations[v1alpha1.ClusterImageRegistriesAnnotation], err)
+		return imageName, err
 	}
 
 	if len(imageRegistries.Registries) == 0 {
-		return imageName
+		return imageName, nil
 	}
 	overrideImageName := imageName
 	for i := 0; i < len(imageRegistries.Registries); i++ {
@@ -131,5 +146,5 @@ func OverrideImageByAnnotation(annotations map[string]string, imageName string) 
 			overrideImageName = name
 		}
 	}
-	return overrideImageName
+	return overrideImageName, nil
 }

--- a/pkg/helpers/imageregistry/client_test.go
+++ b/pkg/helpers/imageregistry/client_test.go
@@ -77,14 +77,14 @@ func Test_ClientPullSecret(t *testing.T) {
 			name:               "failed to get pullSecret pullSecret without annotation",
 			client:             fakeClient(newPullSecret("ns1", "pullSecret")),
 			cluster:            newCluster("cluster1", ""),
-			expectedErr:        fmt.Errorf("invalid pullSecret in the annotation %s", v1alpha1.ClusterImageRegistriesAnnotation),
+			expectedErr:        nil,
 			expectedPullSecret: nil,
 		},
 		{
 			name:               "failed to get pullSecret pullSecret with wrong annotation",
 			client:             fakeClient(newPullSecret("ns1", "pullSecret")),
 			cluster:            newCluster("cluster1", "abc"),
-			expectedErr:        fmt.Errorf("invalid pullSecret in the annotation %s", v1alpha1.ClusterImageRegistriesAnnotation),
+			expectedErr:        fmt.Errorf("invalid character 'a' looking for beginning of value"),
 			expectedPullSecret: nil,
 		},
 		{
@@ -99,10 +99,12 @@ func Test_ClientPullSecret(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			pullSecret, err := c.client.Cluster(c.cluster).PullSecret()
-			if err != nil && c.expectedErr != nil {
-				if err.Error() != c.expectedErr.Error() {
-					t.Errorf("expected err %v, but got %v", c.expectedErr, err)
-				}
+			if (err != nil && c.expectedErr == nil) || (err == nil && c.expectedErr != nil) {
+				t.Errorf("expected error %v, but got %v", c.expectedErr, err)
+			}
+
+			if err != nil && c.expectedErr != nil && err.Error() != c.expectedErr.Error() {
+				t.Errorf("expected err %v, but got %v", c.expectedErr, err)
 			}
 			if pullSecret != nil && c.expectedPullSecret != nil {
 				if pullSecret.Name != c.expectedPullSecret.Name {
@@ -119,6 +121,7 @@ func Test_ClientImageOverride(t *testing.T) {
 		image         string
 		cluster       *clusterv1.ManagedCluster
 		expectedImage string
+		expectedErr   error
 	}{
 		{
 			name: "override rhacm2 image ",
@@ -127,6 +130,7 @@ func Test_ClientImageOverride(t *testing.T) {
 				{Source: "registry.redhat.io/multicluster-engine", Mirror: "quay.io/multicluster-engine"}}, "")),
 			image:         "registry.redhat.io/rhacm2/registration@SHA256abc",
 			expectedImage: "quay.io/rhacm2/registration@SHA256abc",
+			expectedErr:   nil,
 		},
 		{
 			name: "override acm-d image",
@@ -135,6 +139,7 @@ func Test_ClientImageOverride(t *testing.T) {
 				{Source: "registry.redhat.io/multicluster-engine", Mirror: "quay.io/multicluster-engine"}}, "")),
 			image:         "registry.redhat.io/acm-d/registration@SHA256abc",
 			expectedImage: "registry.redhat.io/acm-d/registration@SHA256abc",
+			expectedErr:   nil,
 		},
 		{
 			name: "override multicluster-engine image",
@@ -143,6 +148,7 @@ func Test_ClientImageOverride(t *testing.T) {
 				{Source: "registry.redhat.io/multicluster-engine", Mirror: "quay.io/multicluster-engine"}}, "")),
 			image:         "registry.redhat.io/multicluster-engine/registration@SHA256abc",
 			expectedImage: "quay.io/multicluster-engine/registration@SHA256abc",
+			expectedErr:   nil,
 		},
 		{
 			name: "override image without source ",
@@ -150,6 +156,7 @@ func Test_ClientImageOverride(t *testing.T) {
 				{Source: "", Mirror: "quay.io/rhacm2"}}, "")),
 			image:         "registry.redhat.io/multicluster-engine/registration@SHA256abc",
 			expectedImage: "quay.io/rhacm2/registration@SHA256abc",
+			expectedErr:   nil,
 		},
 		{
 			name: "override image",
@@ -159,31 +166,48 @@ func Test_ClientImageOverride(t *testing.T) {
 					Mirror: "quay.io/acm-d/registration:latest"}}, "")),
 			image:         "registry.redhat.io/rhacm2/registration@SHA256abc",
 			expectedImage: "quay.io/acm-d/registration:latest",
+			expectedErr:   nil,
 		},
 		{
 			name:          "return image without annotation",
 			cluster:       newCluster("c1", ""),
 			image:         "registry.redhat.io/rhacm2/registration@SHA256abc",
 			expectedImage: "registry.redhat.io/rhacm2/registration@SHA256abc",
+			expectedErr:   nil,
 		},
 		{
 			name:          "return image with wrong annotation",
 			cluster:       newCluster("c1", "abc"),
 			image:         "registry.redhat.io/rhacm2/registration@SHA256abc",
 			expectedImage: "registry.redhat.io/rhacm2/registration@SHA256abc",
+			expectedErr:   fmt.Errorf("invalid character 'a' looking for beginning of value"),
 		},
 	}
 	client := fakeClient(newPullSecret("n1", "s1"))
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			if client.Cluster(c.cluster).ImageOverride(c.image) != c.expectedImage {
-				t.Errorf("expected image %v but got %v", c.expectedImage,
-					client.Cluster(c.cluster).ImageOverride(c.image))
+			image, err := client.Cluster(c.cluster).ImageOverride(c.image)
+			if image != c.expectedImage {
+				t.Errorf("expected image %v but got %v", c.expectedImage, image)
 			}
 
-			if OverrideImageByAnnotation(c.cluster.GetAnnotations(), c.image) != c.expectedImage {
-				t.Errorf("expected image %v but got %v", c.expectedImage,
-					OverrideImageByAnnotation(c.cluster.GetAnnotations(), c.image))
+			if (err != nil && c.expectedErr == nil) || (err == nil && c.expectedErr != nil) {
+				t.Errorf("expected error %v, but got %v", c.expectedErr, err)
+			}
+
+			if err != nil && c.expectedErr != nil && err.Error() != c.expectedErr.Error() {
+				t.Errorf("expected error %v, but got %v", c.expectedErr, err)
+			}
+
+			image, err = OverrideImageByAnnotation(c.cluster.GetAnnotations(), c.image)
+			if image != c.expectedImage {
+				t.Errorf("expected image %v but got %v", c.expectedImage, image)
+			}
+			if (err != nil && c.expectedErr == nil) || (err == nil && c.expectedErr != nil) {
+				t.Errorf("expected error %v, but got %v", c.expectedErr, err)
+			}
+			if err != nil && c.expectedErr != nil && err.Error() != c.expectedErr.Error() {
+				t.Errorf("expected error %v, but got %v", c.expectedErr, err)
 			}
 		})
 	}

--- a/test/e2e/imageregistry_test.go
+++ b/test/e2e/imageregistry_test.go
@@ -113,9 +113,11 @@ var _ = ginkgo.Describe("Testing ManagedClusterImageRegistry", func() {
 		// should override the image successfully
 		imageName := "registry.redhat.io/multicluster-engine/registration@SHA256abc"
 		expectedImageName := "quay.io/multicluster-engine/registration@SHA256abc"
-		overrideImageName := imageRegistryClient.Cluster(cluster).ImageOverride(imageName)
+		overrideImageName, err := imageRegistryClient.Cluster(cluster).ImageOverride(imageName)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(overrideImageName).Should(gomega.Equal(expectedImageName))
-		overrideImageName = imageregistry.OverrideImageByAnnotation(cluster.GetAnnotations(), imageName)
+		overrideImageName, err = imageregistry.OverrideImageByAnnotation(cluster.GetAnnotations(), imageName)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(overrideImageName).Should(gomega.Equal(expectedImageName))
 
 		// remove the cluster from the placement
@@ -154,7 +156,8 @@ var _ = ginkgo.Describe("Testing ManagedClusterImageRegistry", func() {
 		// override the image successfully
 		imageName = "registry.redhat.io/multicluster-engine/registration@SHA256abc"
 		expectedImageName = "registry.redhat.io/multicluster-engine/registration@SHA256abc"
-		overrideImageName = imageRegistryClient.Cluster(cluster).ImageOverride(imageName)
+		overrideImageName, err = imageRegistryClient.Cluster(cluster).ImageOverride(imageName)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		gomega.Expect(overrideImageName).Should(gomega.Equal(expectedImageName))
 	})
 })


### PR DESCRIPTION
Signed-off-by: Zhiwei Yin <zyin@redhat.com>

1. fix issue: https://github.com/stolostron/backlog/issues/21853
OCP 311 has route, support to get log using route.

2. fix issue: https://github.com/stolostron/backlog/issues/21554
work-agent cannot update service if the type of service is changed in OCP 311, and return error 
`invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'`
this is an issue in old k8s version,  has been fixed in new one. https://github.com/kubernetes/kubectl/issues/221
the fix in addon is that deploy service until the product claim has value. will not update it in addon manifestwork.

3. return error for the interface of the imageRegisty Client to help debug. 