### PR TITLE
Add env for registration operator branch

### DIFF
--- a/deploy/managedcluster/hub/install.sh
+++ b/deploy/managedcluster/hub/install.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 KUBECTL=${KUBECTL:-kubectl}
+REGISTRATION_OPERATOR_BRANCH=${REGISTRATION_OPERATOR_BRANCH:-main}
 
 # On openshift, OLM is installed into openshift-operator-lifecycle-manager
 $KUBECTL get namespace openshift-operator-lifecycle-manager 1>/dev/null 2>&1
@@ -15,7 +16,7 @@ fi
 rm -rf registration-operator
 
 echo "############  Cloning registration-operator"
-git clone https://github.com/open-cluster-management-io/registration-operator.git
+git clone --depth 1 --branch "$REGISTRATION_OPERATOR_BRANCH" https://github.com/stolostron/registration-operator.git
 
 cd registration-operator || {
   printf "cd failed, registration-operator does not exist"

--- a/deploy/managedcluster/klusterlet/install.sh
+++ b/deploy/managedcluster/klusterlet/install.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 KUBECTL=${KUBECTL:-kubectl}
+REGISTRATION_OPERATOR_BRANCH=${REGISTRATION_OPERATOR_BRANCH:-main}
 
 # On openshift, OLM is installed into openshift-operator-lifecycle-manager
 $KUBECTL get namespace openshift-operator-lifecycle-manager 1>/dev/null 2>&1
@@ -15,7 +16,7 @@ fi
 rm -rf registration-operator
 
 echo "############  Cloning registration-operator"
-git clone https://github.com/open-cluster-management-io/registration-operator.git
+git clone --depth 1 --branch "$REGISTRATION_OPERATOR_BRANCH" https://github.com/stolostron/registration-operator.git
 
 cd registration-operator || {
   printf "cd failed, registration-operator does not exist"


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

After this is merged, we can use prow config to `export REGISTRATION_OPERATOR_BRANCH` to control the OCM version.