### PR TITLE
update the criteria for determining worker nodes

### DIFF
--- a/pkg/controllers/clusterinfo/capacity_controller.go
+++ b/pkg/controllers/clusterinfo/capacity_controller.go
@@ -17,9 +17,12 @@ import (
 )
 
 const (
-	resourceSocket       clusterv1.ResourceName = "socket"
-	resourceCoreWorker   clusterv1.ResourceName = "core_worker"
-	resourceSocketWorker clusterv1.ResourceName = "socket_worker"
+	resourceSocket               clusterv1.ResourceName = "socket"
+	resourceCoreWorker           clusterv1.ResourceName = "core_worker"
+	resourceSocketWorker         clusterv1.ResourceName = "socket_worker"
+	LabelNodeRoleOldControlPlane                        = "node-role.kubernetes.io/master"
+	LabelNodeRoleControlPlane                           = "node-role.kubernetes.io/control-plane"
+	LabelNodeRoleInfra                                  = "node-role.kubernetes.io/infra"
 )
 
 type CapacityReconciler struct {
@@ -62,12 +65,21 @@ func (r *CapacityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	nodes := clusterInfo.Status.NodeList
 	socketWorkerCapacity := *resource.NewQuantity(int64(0), resource.DecimalSI)
 	coreWorkerCapacity := *resource.NewQuantity(int64(0), resource.DecimalSI)
-	for _, node := range nodes {
-		if isWorker(node) {
-			coreWorkerCapacity.Add(node.Capacity[clusterv1.ResourceCPU])
-			socketWorkerCapacity.Add(node.Capacity[resourceSocket])
+
+	// for OCP calculate cpu/socket on all worker nodes.
+	// for non-OCP, calculate cpu on all nodes.
+	// only support to get socket on OCP.
+	if clusterInfo.Status.DistributionInfo.Type == clusterinfov1beta1.DistributionTypeOCP {
+		for _, node := range nodes {
+			if isWorker(node) {
+				coreWorkerCapacity.Add(node.Capacity[clusterv1.ResourceCPU])
+				socketWorkerCapacity.Add(node.Capacity[resourceSocket])
+			}
 		}
+	} else {
+		coreWorkerCapacity = capacity[clusterv1.ResourceCPU]
 	}
+
 	capacity[resourceSocketWorker] = socketWorkerCapacity
 	capacity[resourceCoreWorker] = coreWorkerCapacity
 
@@ -79,14 +91,18 @@ func (r *CapacityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, r.client.Status().Update(ctx, cluster)
 }
 
+// for OCP,the master and infra nodes are not included in the subscription cost calculation.
 func isWorker(node clusterinfov1beta1.NodeStatus) bool {
 	if node.Labels == nil {
-		return false
-	}
-
-	if _, ok := node.Labels["node-role.kubernetes.io/worker"]; ok {
 		return true
 	}
 
-	return false
+	for key := range node.Labels {
+		switch key {
+		case LabelNodeRoleOldControlPlane, LabelNodeRoleControlPlane, LabelNodeRoleInfra:
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/controllers/clusterinfo/capacity_controller_test.go
+++ b/pkg/controllers/clusterinfo/capacity_controller_test.go
@@ -41,26 +41,38 @@ func TestCapacityReconcile(t *testing.T) {
 		{
 			name:               "ManagedClusterNotFound",
 			existingCluster:    newCluster("bar", nil),
-			existinClusterInfo: newClusterInfo("bar", nil, 1),
+			existinClusterInfo: newClusterInfo("bar", true, nil, 1),
 			expectedNotFound:   true,
 		},
 		{
 			name:               "ManagedClusterInfoNotFound",
 			existingCluster:    newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 1}),
-			existinClusterInfo: newClusterInfo("bar", nil, 1),
+			existinClusterInfo: newClusterInfo("bar", true, nil, 1),
 			expectedCapacity:   newCapacity(map[clusterv1.ResourceName]int64{"cpu": 1}),
 		},
 		{
-			name:               "UpdateManagedClusterCapacity",
-			existingCluster:    newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 1}),
-			existinClusterInfo: newClusterInfo(ManagedClusterName, map[string]bool{"node1": false}, 2),
-			expectedCapacity:   newCapacity(map[clusterv1.ResourceName]int64{"cpu": 1, "socket_worker": 0, "core_worker": 0}),
+			name:            "Do not update ocp Capacity",
+			existingCluster: newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 1}),
+			existinClusterInfo: newClusterInfo(ManagedClusterName, true,
+				map[string]string{"node1": LabelNodeRoleOldControlPlane, "node2": LabelNodeRoleControlPlane}, 2),
+			expectedCapacity: newCapacity(map[clusterv1.ResourceName]int64{"cpu": 1, "socket_worker": 0, "core_worker": 0}),
 		},
 		{
-			name:               "UpdateManagedClusterCapacityWithWorker",
-			existingCluster:    newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 1}),
-			existinClusterInfo: newClusterInfo(ManagedClusterName, map[string]bool{"node1": false, "node2": true}, 2),
-			expectedCapacity:   newCapacity(map[clusterv1.ResourceName]int64{"cpu": 1, "socket_worker": 2, "core_worker": 2}),
+			name:            "Update ocp Capacity",
+			existingCluster: newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 1}),
+			existinClusterInfo: newClusterInfo(ManagedClusterName, true,
+				map[string]string{"node1": LabelNodeRoleControlPlane, "node2": LabelNodeRoleInfra,
+					"node3": "node-role.kubernetes.io/worker", "node4": ""}, 2),
+			expectedCapacity: newCapacity(map[clusterv1.ResourceName]int64{"cpu": 1, "socket_worker": 4, "core_worker": 4}),
+		},
+
+		{
+			name:            "Update non-ocp Capacity",
+			existingCluster: newCluster(ManagedClusterName, map[clusterv1.ResourceName]int64{"cpu": 8}),
+			existinClusterInfo: newClusterInfo(ManagedClusterName, false,
+				map[string]string{"node1": LabelNodeRoleControlPlane, "node2": LabelNodeRoleInfra,
+					"node3": "node-role.kubernetes.io/worker", "node4": ""}, 2),
+			expectedCapacity: newCapacity(map[clusterv1.ResourceName]int64{"cpu": 8, "socket_worker": 0, "core_worker": 8}),
 		},
 	}
 
@@ -96,7 +108,7 @@ func newCluster(name string, resources map[clusterv1.ResourceName]int64) *cluste
 	}
 }
 
-func newClusterInfo(name string, resources map[string]bool, val int64) *clusterv1beta1.ManagedClusterInfo {
+func newClusterInfo(name string, isOCP bool, nodes map[string]string, val int64) *clusterv1beta1.ManagedClusterInfo {
 	info := &clusterv1beta1.ManagedClusterInfo{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -106,19 +118,20 @@ func newClusterInfo(name string, resources map[string]bool, val int64) *clusterv
 			NodeList: []clusterv1beta1.NodeStatus{},
 		},
 	}
+	if isOCP {
+		info.Status.DistributionInfo.Type = clusterv1beta1.DistributionTypeOCP
+	}
 
-	for name, isworker := range resources {
+	for nodeName, nodeRole := range nodes {
 		node := clusterv1beta1.NodeStatus{
-			Name: name,
+			Name: nodeName,
 			Capacity: clusterv1beta1.ResourceList{
 				"cpu":    *resource.NewQuantity(val, resource.DecimalSI),
 				"socket": *resource.NewQuantity(val, resource.DecimalSI),
 			},
 		}
-		if isworker {
-			node.Labels = map[string]string{
-				"node-role.kubernetes.io/worker": "",
-			}
+		node.Labels = map[string]string{
+			nodeRole: "",
 		}
 		info.Status.NodeList = append(info.Status.NodeList, node)
 	}


### PR DESCRIPTION
core_worker and socket_worker are collected by acm_managed_cluster_info metric for billing, 
so need calculate all nodes where the workloads can be placed. so calculate the data from all nodes we can get .

story: https://issues.redhat.com/browse/ACM-3464
Signed-off-by: Zhiwei Yin <zyin@redhat.com>