### PR TITLE
update cluster capacity only when cluster is available

### DIFF
--- a/pkg/controllers/clusterinfo/capacity_controller.go
+++ b/pkg/controllers/clusterinfo/capacity_controller.go
@@ -6,6 +6,7 @@ import (
 	clusterinfov1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,6 +50,12 @@ func (r *CapacityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !cluster.GetDeletionTimestamp().IsZero() {
 		return reconcile.Result{}, nil
 	}
+
+	if !meta.IsStatusConditionTrue(cluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable) {
+		// only update the capacity when cluster is available
+		return reconcile.Result{}, nil
+	}
+
 	capacity := cluster.DeepCopy().Status.Capacity
 	if capacity == nil {
 		capacity = clusterv1.ResourceList{}

--- a/pkg/controllers/clusterinfo/capacity_controller_test.go
+++ b/pkg/controllers/clusterinfo/capacity_controller_test.go
@@ -103,6 +103,12 @@ func newCluster(name string, resources map[clusterv1.ResourceName]int64) *cluste
 			Name: name,
 		},
 		Status: clusterv1.ManagedClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   clusterv1.ManagedClusterConditionAvailable,
+					Status: metav1.ConditionTrue,
+				},
+			},
 			Capacity: newCapacity(resources),
 		},
 	}


### PR DESCRIPTION
to avoid update conflict error  

```
{"level":"error","ts":"2023-05-11T09:37:31Z","msg":"Reconciler error","controller":"clustercapcity-controller","object":{"name":"hosted","namespace":"hosted"},"namespace":"hosted","name":"hosted","reconcileID":"45e79b82-0221-461b-be7a-7f40d17a3173","error":"ManagedCluster.cluster.open-cluster-management.io \"hosted\" is invalid: status.conditions: Invalid value: \"null\": status.conditions in body must be of type array: \"null\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"}

{"level":"error","ts":"2023-05-11T13:08:57Z","msg":"Reconciler error","controller":"clusterinfo-controller","object":{"name":"hosted"},"namespace":"","name":"hosted","reconcileID":"04248246-de24-43a8-8297-8de51bbfdd02","error":"Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io \"hosted\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/workspace/multicluster-controlplane/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"}
```