### PR TITLE
Use appsDomain if it is set when determining Route host

### DIFF
--- a/pkg/klusterlet/clusterinfo/loggingInfo_sync.go
+++ b/pkg/klusterlet/clusterinfo/loggingInfo_sync.go
@@ -206,6 +206,11 @@ func (s *loggingInfoSyncer) getIngressDomain(ctx context.Context) (string, error
 	if err != nil {
 		return "", fmt.Errorf("failed to get configv1.ingress. error %v", err)
 	}
+
+	if clusterIngress.Spec.AppsDomain != "" {
+		return clusterIngress.Spec.AppsDomain, nil
+	}
+
 	if clusterIngress.Spec.Domain == "" {
 		return "", fmt.Errorf("ingress domain not found or empty in Ingress")
 	}


### PR DESCRIPTION
See this doc: https://docs.openshift.com/container-platform/4.12/networking/ingress-operator.html#nw-ingress-configuring-application-domain_configuring-ingress

If appsDomain is set, it should override whatever is set in `domain` when creating a Route.

This illustrates the problem:
```
[loganmc10@fedoralogan ~]$ oc get route -A
NAMESPACE                             NAME                       HOST/PORT                                                             PATH        SERVICES                   PORT    TERMINATION            WILDCARD
open-cluster-management-agent-addon   klusterlet-addon-workmgr   workmgr-f237a30cbe328fa345042ce3db57ffb5.apps.smb.bacoosta.com                    klusterlet-addon-workmgr   <all>   passthrough            None
openshift-authentication              oauth-openshift            oauth-openshift.apps.smb2.bacoosta.com                                            oauth-openshift            6443    passthrough/Redirect   None
openshift-ingress-canary              canary                     canary-openshift-ingress-canary.apps.smb2.bacoosta.com                            ingress-canary             8080    edge/Redirect          None
openshift-monitoring                  alertmanager-main          alertmanager-main-openshift-monitoring.apps.smb2.bacoosta.com         /api        alertmanager-main          web     reencrypt/Redirect     None
openshift-monitoring                  prometheus-k8s             prometheus-k8s-openshift-monitoring.apps.smb2.bacoosta.com            /api        prometheus-k8s             web     reencrypt/Redirect     None
openshift-monitoring                  prometheus-k8s-federate    prometheus-k8s-federate-openshift-monitoring.apps.smb2.bacoosta.com   /federate   prometheus-k8s             web     reencrypt/Redirect     None
openshift-monitoring                  thanos-querier             thanos-querier-openshift-monitoring.apps.smb2.bacoosta.com            /api        thanos-querier             web     reencrypt/Redirect     None
```

If I change my cluster Ingress domain to `smb2.bacoosta.com` by changing the `appsDomain` value, every Route uses that new domain, except the `klusterlet-addon-workmgr` route, which continues to use the old `smb.bacoosta.com` domain