### PR TITLE
[backplane-2.2] downgrade min TLS version to 1.2

### DIFF
--- a/cmd/proxyserver/app/options/options.go
+++ b/cmd/proxyserver/app/options/options.go
@@ -3,6 +3,7 @@
 package options
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/spf13/pflag"
@@ -70,12 +71,13 @@ func (o *Options) APIServerConfig() (*genericapiserver.Config, error) {
 	if err := o.SecureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
 		return nil, err
 	}
+	serverConfig.SecureServing.MinTLSVersion = tls.VersionTLS12
 
 	if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
 		return nil, err
 	}
 
-	//TODO: add custormer authorization here
+	// TODO: add custormer authorization here
 	if err := o.Authorization.ApplyTo(&serverConfig.Authorization); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix https://access.redhat.com/security/cve/CVE-2023-3089