### PR TITLE
Fix clusterclaim no resource error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Check the [CONTRIBUTING Doc](CONTRIBUTING.md) for how to contribute to the repo.
 
 ------
 
+
 ## Getting Started
 
 This is a guide on how to build and deploy stolostron Foundation from code.
@@ -24,10 +25,10 @@ make images
 
 ### Prerequisites
 
-Need to install **Cluster Manager** and **Klusterlet** before deploy Foundation components. The installation instruction is [here](https://open-cluster-management.io). 
+Need to install **Cluster Manager** and **Klusterlet** before deploy Foundation components. The installation instruction is [here](https://open-cluster-management.io).
 
 Need to approve and accept the managed clusters registered to the Hub.
- 
+
 * Approve CSR on Hub cluster.
 
     ```sh


### PR DESCRIPTION
Error msg:
```
E0904 13:05:57.448095 1 clusterclaimer.go:326] failed to mapping project:failed to get API group resources: unable to retrieve the complete list of server APIs: aro.openshift.io/v1alpha1: the server could not find the requested resource
E0904 13:05:57.448130 1 clusterclaimer.go:617] failed to check if cluster is ARO. failed to get API group resources: unable to retrieve the complete list of server APIs: aro.openshift.io/v1alpha1: the server could not find the requested resource
E0904 13:05:57.448179 1 clusterclaimer.go:167] failed to update platform and product. err:failed to get API group resources: unable to retrieve the complete list of server APIs: aro.openshift.io/v1alpha1: the server could not find the requested resource
2023-09-04T13:05:57Z ERROR Reconciler error {"controller": "ClusterClaim", "object": {"name":""}, "namespace": "", "name": "", "reconcileID": "32793616-9a78-49d4-af53-6d384ac46199", "error": "failed to get API group resources: unable to retrieve the complete list of server APIs: aro.openshift.io/v1alpha1: the server could not find the requested resource"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:324
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226
```