### PR TITLE
Fix: mapping failed.

### DIFF
--- a/pkg/klusterlet/view/view_controller_test.go
+++ b/pkg/klusterlet/view/view_controller_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	gmg "github.com/onsi/gomega"
+	cacheddiscovery "k8s.io/client-go/discovery/cached"
+
 	viewv1beta1 "github.com/stolostron/cluster-lifecycle-api/view/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,18 +18,39 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
 	scheme = runtime.NewScheme()
 )
+
+func setupEnvtest(t *testing.T) (*rest.Config, func(t *testing.T)) {
+	t.Log("Setup envtest")
+
+	testEnv := &envtest.Environment{}
+	g := gmg.NewWithT(t)
+
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(gmg.HaveOccurred())
+	g.Expect(cfg).NotTo(gmg.BeNil())
+
+	teardownFunc := func(t *testing.T) {
+		t.Log("Stop envtest")
+		g.Expect(testEnv.Stop()).To(gmg.Succeed())
+	}
+
+	return cfg, teardownFunc
+}
 
 func TestMain(m *testing.M) {
 	// AddToSchemes may be used to add all resources defined in the project to a Scheme
@@ -66,72 +90,7 @@ func newUnstructured() *unstructured.Unstructured {
 	}
 }
 
-func newTestReconciler(existingObjs []client.Object) *ViewReconciler {
-	resources := []*restmapper.APIGroupResources{
-		{
-			Group: metav1.APIGroup{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-				},
-				Name: "apps",
-				Versions: []metav1.GroupVersionForDiscovery{
-					{
-						GroupVersion: "v1",
-						Version:      "v1",
-					},
-				},
-				PreferredVersion: metav1.GroupVersionForDiscovery{
-					GroupVersion: "v1",
-					Version:      "v1",
-				},
-				ServerAddressByClientCIDRs: nil,
-			},
-			VersionedResources: map[string][]metav1.APIResource{
-				"v1": {
-					{
-						Name:         "deployments",
-						SingularName: "deployment",
-						Group:        "apps",
-						Kind:         "Deployment",
-						Version:      "v1",
-					},
-				},
-			},
-		},
-		{
-			Group: metav1.APIGroup{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Secret",
-					APIVersion: "v1",
-				},
-				Name: "",
-				Versions: []metav1.GroupVersionForDiscovery{
-					{
-						GroupVersion: "v1",
-						Version:      "v1",
-					},
-				},
-				PreferredVersion: metav1.GroupVersionForDiscovery{
-					GroupVersion: "v1",
-					Version:      "v1",
-				},
-				ServerAddressByClientCIDRs: nil,
-			},
-			VersionedResources: map[string][]metav1.APIResource{
-				"v1": {
-					{
-						Name:         "secrets",
-						SingularName: "secret",
-						Group:        "",
-						Kind:         "Secret",
-						Version:      "v1",
-					},
-				},
-			},
-		},
-	}
-
+func newTestReconciler(existingObjs []client.Object, fakeMapper meta.RESTMapper) *ViewReconciler {
 	viewReconciler := &ViewReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithObjects(existingObjs...).WithStatusSubresource(existingObjs...).
@@ -139,7 +98,7 @@ func newTestReconciler(existingObjs []client.Object) *ViewReconciler {
 		Log:                         ctrl.Log.WithName("controllers").WithName("ManagedClusterView"),
 		Scheme:                      scheme,
 		ManagedClusterDynamicClient: dynamicfake.NewSimpleDynamicClient(scheme, newUnstructured()),
-		Mapper:                      newFakeRestMapper(resources),
+		Mapper:                      fakeMapper,
 	}
 
 	return viewReconciler
@@ -220,9 +179,18 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	restCfg, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("Failed to create discovery client, %v", err)
+	}
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(discoveryClient))
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			svrc := newTestReconciler(test.existingObjs)
+			svrc := newTestReconciler(test.existingObjs, restMapper)
 			res, err := svrc.Reconcile(ctx, test.req)
 			validateErrorAndStatusConditions(t, err, test.expectedErrorType, nil, nil)
 
@@ -244,7 +212,7 @@ func TestQueryResource(t *testing.T) {
 		expectedConditions []metav1.Condition
 	}{
 		{
-			name: "queryResourceOK",
+			name: "queryResource Resource Only",
 			managedClusterView: &viewv1beta1.ManagedClusterView{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      managedClusterViewName,
@@ -252,9 +220,7 @@ func TestQueryResource(t *testing.T) {
 				},
 				Spec: viewv1beta1.ViewSpec{
 					Scope: viewv1beta1.ViewScope{
-						Group:     "apps",
-						Version:   "v1",
-						Kind:      "Deployment",
+						Resource:  "deployment",
 						Name:      "deployment_test",
 						Namespace: "default",
 					},
@@ -268,7 +234,7 @@ func TestQueryResource(t *testing.T) {
 			},
 		},
 		{
-			name: "queryResourceOK2",
+			name: "queryResource GVK",
 			managedClusterView: &viewv1beta1.ManagedClusterView{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      managedClusterViewName,
@@ -276,7 +242,9 @@ func TestQueryResource(t *testing.T) {
 				},
 				Spec: viewv1beta1.ViewSpec{
 					Scope: viewv1beta1.ViewScope{
-						Resource:  "deployment",
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
 						Name:      "deployment_test",
 						Namespace: "default",
 					},
@@ -406,15 +374,20 @@ func TestQueryResource(t *testing.T) {
 		},
 	}
 
-	svrc := newTestReconciler([]client.Object{})
+	restCfg, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("Failed to create discovery client, %v", err)
+	}
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(discoveryClient))
+
+	svrc := newTestReconciler([]client.Object{}, restMapper)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := svrc.queryResource(test.managedClusterView)
 			validateErrorAndStatusConditions(t, err, test.expectedErrorType, test.expectedConditions, test.managedClusterView)
 		})
 	}
-}
-
-func newFakeRestMapper(resources []*restmapper.APIGroupResources) meta.RESTMapper {
-	return restmapper.NewDiscoveryRESTMapper(resources)
 }

--- a/vendor/k8s.io/client-go/discovery/cached/legacy.go
+++ b/vendor/k8s.io/client-go/discovery/cached/legacy.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+)
+
+// NewMemCacheClient is DEPRECATED. Use memory.NewMemCacheClient directly.
+func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
+	return memory.NewMemCacheClient(delegate)
+}
+
+// ErrCacheNotFound is DEPRECATED. Use memory.ErrCacheNotFound directly.
+var ErrCacheNotFound = memory.ErrCacheNotFound

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1099,6 +1099,7 @@ k8s.io/client-go/applyconfigurations/storage/v1
 k8s.io/client-go/applyconfigurations/storage/v1alpha1
 k8s.io/client-go/applyconfigurations/storage/v1beta1
 k8s.io/client-go/discovery
+k8s.io/client-go/discovery/cached
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-7479

Root cause: Start with this [PR](https://github.com/kubernetes-sigs/controller-runtime/pull/2296), the behavior of `NewDynamicRESTMapper` changed.

Run this `restMapper.KindFor(&schema.GroupVersionResource{Resource:"deployment"}})`, the results:

Before it returns a `GroupVersionKind`:
```
schema.GroupVersionKind{ Group: "apps", Kind: "Deployment", Version: "v1"}
```

But now, it returns the error:
```
no matches for kind "deployment" in version ""
```

The root cause is in controller-runtime `v0.14.6`, it reloads by this function: https://github.com/kubernetes-sigs/controller-runtime/blob/cd65cb25d314f40a329a688f4714fe3282589e97/pkg/client/apiutil/dynamicrestmapper.go#L94 which caches all groups and resource from discoveryClient.

But after this [PR](https://github.com/kubernetes-sigs/controller-runtime/pull/2296), it reloads by `ServerResourcesForGroupVersion` which makes `version` a required value, and that against our API design of `ManagedClusterView`.