### PR TITLE
Fix: restmapping fail when new crd added.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.11.1 // indirect
-	k8s.io/apiextensions-apiserver v0.27.2 // indirect
+	k8s.io/apiextensions-apiserver v0.27.2
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect

--- a/pkg/klusterlet/view/view_controller_test.go
+++ b/pkg/klusterlet/view/view_controller_test.go
@@ -12,6 +12,7 @@ import (
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
 
 	viewv1beta1 "github.com/stolostron/cluster-lifecycle-api/view/v1beta1"
+	restutil "github.com/stolostron/multicloud-operators-foundation/pkg/utils/rest"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -187,10 +188,11 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("Failed to create discovery client, %v", err)
 	}
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(discoveryClient))
+	reloadMapper := restutil.NewReloadMapper(restMapper)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			svrc := newTestReconciler(test.existingObjs, restMapper)
+			svrc := newTestReconciler(test.existingObjs, reloadMapper)
 			res, err := svrc.Reconcile(ctx, test.req)
 			validateErrorAndStatusConditions(t, err, test.expectedErrorType, nil, nil)
 
@@ -382,8 +384,9 @@ func TestQueryResource(t *testing.T) {
 		t.Fatalf("Failed to create discovery client, %v", err)
 	}
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(discoveryClient))
+	reloadMapper := restutil.NewReloadMapper(restMapper)
 
-	svrc := newTestReconciler([]client.Object{}, restMapper)
+	svrc := newTestReconciler([]client.Object{}, reloadMapper)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := svrc.queryResource(test.managedClusterView)

--- a/pkg/utils/rest/reloadmapper.go
+++ b/pkg/utils/rest/reloadmapper.go
@@ -1,0 +1,80 @@
+package rest
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/restmapper"
+)
+
+type ReloadMapper struct {
+	ddm *restmapper.DeferredDiscoveryRESTMapper
+}
+
+func NewReloadMapper(ddm *restmapper.DeferredDiscoveryRESTMapper) *ReloadMapper {
+	return &ReloadMapper{
+		ddm: ddm,
+	}
+}
+
+func (m *ReloadMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	gvk, err := m.ddm.KindFor(resource)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.KindFor(resource)
+	}
+	return gvk, err
+}
+
+func (m *ReloadMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	gvks, err := m.ddm.KindsFor(resource)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.KindsFor(resource)
+	}
+	return gvks, err
+}
+
+func (m *ReloadMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	gvr, err := m.ddm.ResourceFor(input)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.ResourceFor(input)
+	}
+	return gvr, err
+}
+
+func (m *ReloadMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	gvrs, err := m.ddm.ResourcesFor(input)
+	if err != nil {
+		m.ddm.Reset()
+		return m.ddm.ResourcesFor(input)
+	}
+	return gvrs, err
+}
+
+func (m *ReloadMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	mapping, err := m.ddm.RESTMapping(gk, versions...)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.RESTMapping(gk, versions...)
+	}
+	return mapping, err
+}
+
+func (m *ReloadMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	mappings, err := m.ddm.RESTMappings(gk, versions...)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.RESTMappings(gk, versions...)
+	}
+	return mappings, err
+}
+
+func (m *ReloadMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	singlar, err := m.ddm.ResourceSingularizer(resource)
+	if meta.IsNoMatchError(err) {
+		m.ddm.Reset()
+		return m.ddm.ResourceSingularizer(resource)
+	}
+	return singlar, err
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=open-cluster-management_multicloud-operators-foundation
 sonar.projectName=multicloud-operators-foundation
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,**/test/**,**/cmd/**,**/apis/**,**/api/**,**/klusterlet/log/**,**/klusterlet/agent/**,**/controllers/**,**/proxyserver/rest/**,**/error.go,**/kubecontrol.go,**/manager.go
+sonar.exclusions=**/*_test.go,**/vendor/**,**/test/**,**/cmd/**,**/apis/**,**/api/**,**/klusterlet/log/**,**/klusterlet/agent/**,**/controllers/**,**/proxyserver/rest/**,**/error.go,**/kubecontrol.go,**/manager.go,**reloadmapper.go
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,test/**

--- a/test/e2e/clusterview_test.go
+++ b/test/e2e/clusterview_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stolostron/multicloud-operators-foundation/pkg/helpers"
 	"github.com/stolostron/multicloud-operators-foundation/test/e2e/util"
 	rbacv1 "k8s.io/api/rbac/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stolostron/multicloud-operators-foundation/test/e2e/util"
 
 	hiveclient "github.com/openshift/hive/pkg/client/clientset/versioned"
+	apixv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
@@ -32,6 +33,7 @@ const (
 )
 
 var (
+	apixClient            apixv1client.ApiextensionsV1Interface
 	dynamicClient         dynamic.Interface
 	kubeClient            kubernetes.Interface
 	hiveClient            hiveclient.Interface
@@ -62,6 +64,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	if foundationNS == "" {
 		foundationNS = "open-cluster-management"
 	}
+
+	apixClient, err = util.NewAPIExtensionClient()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	dynamicClient, err = util.NewDynamicClient()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+
+	apixv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 )
 
 const kubeConfigFileEnv = "KUBECONFIG"
@@ -82,6 +84,20 @@ func NewKubeClient() (kubernetes.Interface, error) {
 	}
 
 	return kubernetes.NewForConfig(cfg)
+}
+
+func NewAPIExtensionClient() (apixv1client.ApiextensionsV1Interface, error) {
+	kubeConfigFile, err := getKubeConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return apixv1client.NewForConfig(cfg)
 }
 
 func NewOCPClient() (openshiftclientset.Interface, error) {


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ACM-7479

`DefferdDiscoveryRestMapper` requires explicily reload when`IsNotMatch` error occurs.