### PR TITLE
Refactor: klusterlet claims

### DIFF
--- a/pkg/klusterlet/clusterclaim/clusterclaim_controller.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaim_controller.go
@@ -4,98 +4,295 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 
 	"github.com/go-logr/logr"
+	clusterv1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
-	clusterv1alpha1informer "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1alpha1"
+	clusterv1alpha1lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1alpha1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ListClusterClaimsFunc func() ([]*clusterv1alpha1.ClusterClaim, error)
+func NewClusterClaimReconciler(
+	log logr.Logger,
+	clusterName string,
+	clusterClient clusterclientset.Interface,
+	hubClient client.Client,
+	clusterClaimLister clusterv1alpha1lister.ClusterClaimLister,
+	generateExpectClusterClaims func() ([]*clusterv1alpha1.ClusterClaim, error),
+	enableSyncLabelsToClaim bool) (*clusterClaimReconciler, error) {
 
-// ClusterClaimReconciler reconciles cluster claim objects
-type ClusterClaimReconciler struct {
-	Log               logr.Logger
-	ListClusterClaims ListClusterClaimsFunc
-	ClusterClient     clusterclientset.Interface
-	ClusterInformers  clusterv1alpha1informer.ClusterClaimInformer
+	hubManaged, err := labels.NewRequirement(labelHubManaged, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+	notCustomizedOnly, err := labels.NewRequirement(labelCustomizedOnly, selection.DoesNotExist, nil)
+	if err != nil {
+		return nil, err
+	}
+	customizedOnly, err := labels.NewRequirement(labelCustomizedOnly, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clusterClaimReconciler{
+		log:                         log,
+		clusterName:                 clusterName,
+		clusterClient:               clusterClient,
+		clusterClaimLister:          clusterClaimLister,
+		hubClient:                   hubClient,
+		generateExpectClusterClaims: generateExpectClusterClaims,
+		hubManagedSelector:          labels.NewSelector().Add(*hubManaged).Add(*notCustomizedOnly),
+		customizedOnlyselector:      labels.NewSelector().Add(*hubManaged).Add(*customizedOnly),
+		enableSyncLabelsToClaim:     enableSyncLabelsToClaim,
+	}, nil
 }
 
-func (r *ClusterClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// clusterClaimReconciler reconciles cluster claim objects
+type clusterClaimReconciler struct {
+	log                         logr.Logger
+	clusterName                 string
+	clusterClient               clusterclientset.Interface
+	clusterClaimLister          clusterv1alpha1lister.ClusterClaimLister
+	hubClient                   client.Client
+	generateExpectClusterClaims func() ([]*clusterv1alpha1.ClusterClaim, error)
+
+	hubManagedSelector     labels.Selector // used to filter claims that generaed by the control-plane
+	customizedOnlyselector labels.Selector // used to filter claims that created by user via managedclusterinfo labels
+
+	enableSyncLabelsToClaim bool
+}
+
+func (r *clusterClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.log.V(4).Info("Sync cluster claims")
 	err := r.syncClaims(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if r.enableSyncLabelsToClaim {
+		return ctrl.Result{}, r.syncLabelsToClaims(ctx)
+	}
 	return ctrl.Result{}, err
 }
 
-func (r *ClusterClaimReconciler) syncClaims(ctx context.Context) error {
-	r.Log.V(4).Info("Sync cluster claims")
-	claims, err := r.ListClusterClaims()
+func (r *clusterClaimReconciler) syncClaims(ctx context.Context) error {
+	// Get expected claims
+	expectClaims, err := r.generateExpectClusterClaims()
 	if err != nil {
 		return err
 	}
 
+	// Create/Update claims.
 	errs := []error{}
-	claimSet := sets.String{}
-
-	for _, claim := range claims {
-		if err := r.createOrUpdate(ctx, claim, clusterClaimCreateOnlyList); err != nil {
+	for _, c := range expectClaims {
+		if err := createOrUpdateClusterClaim(ctx, r.clusterClient, c, updateChecks); err != nil {
 			errs = append(errs, err)
 		}
-		claimSet.Insert(claim.Name)
 	}
-
-	labelSelector := fmt.Sprintf("%s=%s", labelHubManaged, "")
-	existedObjs, err := r.ClusterClient.ClusterV1alpha1().ClusterClaims().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil {
-		errs = append(errs, client.IgnoreNotFound(err))
+	if len(errs) != 0 {
 		return utils.NewMultiLineAggregate(errs)
 	}
 
-	for _, claim := range existedObjs.Items {
-		// these claims should not be deleted in any scenario once they are created.
-		switch claim.Name {
-		case ClaimK8sID, ClaimOCMKubeVersion, ClaimOCMPlatform, ClaimOCMProduct, ClaimOpenshiftVersion, ClaimOpenshiftID:
-			continue
-		}
+	// List existing claims then fileter out stable claims
+	existClusterClaims, err := r.clusterClaimLister.List(r.hubManagedSelector)
+	if err != nil {
+		return err
+	}
+	existClusterClaims = filterOutStableClaims(existClusterClaims)
 
-		if claimSet.Has(claim.Name) {
-			continue
-		}
-		err := r.ClusterClient.ClusterV1alpha1().ClusterClaims().Delete(ctx, claim.Name, metav1.DeleteOptions{})
-		if err != nil {
+	//  Clean unexpected ones.
+	return cleanClusterClaims(ctx, r.clusterClient, existClusterClaims, expectClaims)
+}
+
+func (r *clusterClaimReconciler) syncLabelsToClaims(ctx context.Context) error {
+	var err error
+	// Get Claims from managed cluster info
+	expectClaims, err := genLabelsToClaims(r.hubClient, r.clusterName)
+	if err != nil {
+		return err
+	}
+
+	// Create/Update claims.
+	errs := []error{}
+	for _, claim := range expectClaims {
+		if err := createOrUpdateClusterClaim(ctx, r.clusterClient, claim, nil); err != nil {
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) != 0 {
+		return utils.NewMultiLineAggregate(errs)
+	}
 
-	return utils.NewMultiLineAggregate(errs)
+	// List existing claims.
+	existClusterClaims, err := r.clusterClaimLister.List(r.customizedOnlyselector)
+	if err != nil {
+		return err
+	}
+
+	// Clean unexpected ones.
+	return cleanClusterClaims(ctx, r.clusterClient, existClusterClaims, expectClaims)
 }
 
-func (r *ClusterClaimReconciler) createOrUpdate(ctx context.Context, newClaim *clusterv1alpha1.ClusterClaim, clusterClaimCreateOnlyList []string) error {
-	oldClaim, err := r.ClusterClient.ClusterV1alpha1().ClusterClaims().Get(ctx, newClaim.Name, metav1.GetOptions{})
+func genLabelsToClaims(hubClient client.Client, clusterName string) ([]*clusterv1alpha1.ClusterClaim, error) {
+	var claims []*clusterv1alpha1.ClusterClaim
+	request := types.NamespacedName{Namespace: clusterName, Name: clusterName}
+	clusterInfo := &clusterv1beta1.ManagedClusterInfo{}
+	err := hubClient.Get(context.TODO(), request, clusterInfo)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return claims, nil
+		}
+		return claims, err
+	}
+
+	// do not create claim if the label is managed by ACM.
+	// if the label format is aaa/bbb, the name of claim will be bbb.aaa.
+	// Besides, "_" and "/" in the label name will be replaced with "-" and "." respectively.
+	for label, value := range clusterInfo.Labels {
+		if internalLabels.Has(label) || strings.Contains(label, "open-cluster-management.io") {
+			continue
+		}
+
+		// convert the string to lower case
+		name := strings.ToLower(label)
+
+		// and then replace invalid characters
+		subs := strings.Split(name, "/")
+		if len(subs) == 2 {
+			name = fmt.Sprintf("%s.%s", subs[1], subs[0])
+		} else if len(subs) > 2 {
+			name = strings.ReplaceAll(name, "/", ".")
+		}
+		name = strings.ReplaceAll(name, "_", "-")
+
+		// ignore the label if the transformed name is still not a valid resource name
+		if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
+			klog.V(4).Infof("skip syncing label %q of ManagedClusterInfo to ClusterCliam because it's an invalid resource name", label)
+			continue
+		}
+
+		// ignore the label if its value is empty. (the value of ClusterCliam can not be empty)
+		if len(value) == 0 {
+			klog.V(4).Infof("skip syncing label %q of ManagedClusterInfo to ClusterClaim because its value is empty.", label)
+			continue
+		}
+
+		claim := newClusterClaim(name, value)
+		if claim.Labels != nil {
+			claim.Labels[labelCustomizedOnly] = ""
+		}
+		claims = append(claims, claim)
+	}
+	return claims, nil
+}
+
+func filterOutStableClaims(claims []*clusterv1alpha1.ClusterClaim) (filtered []*clusterv1alpha1.ClusterClaim) {
+	for _, c := range claims {
+		if !stableClaims.Has(c.Name) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+type updateCheck func(oldClaim, newClaim *clusterv1alpha1.ClusterClaim) bool
+
+// There are 3 cases that we don't want to update ClusterClaim:
+//  1. newClaim.Name is in clusterClaimCreateOnlyList
+//  2. oldClaim.Name is ClaimOCMProduct and oldClaim.Spec.Value is not empty
+//     and newClaim.Spec.Value is ProductOther
+//  3. oldClaim.Name is ClaimOCMPlatform and oldClaim.Spec.Value is not empty
+//     and newClaim.Spec.Value is PlatformOther
+//
+// In a word, for product and platform, we don't want update them from a specific value to "Other".
+// This is because in the process of upgrading, platform and product could be detected as "Other"
+// then reflect on the console.
+var updateChecks = []updateCheck{
+	func(oldClaim, newClaim *clusterv1alpha1.ClusterClaim) bool {
+		return !utils.ContainsString(clusterClaimCreateOnlyList, newClaim.Name) &&
+			oldClaim.Spec.Value != ""
+	},
+	func(oldClaim, newClaim *clusterv1alpha1.ClusterClaim) bool {
+		// only check ClaimOCMProduct
+		if oldClaim.Name != ClaimOCMProduct {
+			return true
+		}
+		// don't allow update from a specific value to "Other"
+		if newClaim.Spec.Value == ProductOther {
+			return false
+		}
+		return true
+	},
+	func(oldClaim, newClaim *clusterv1alpha1.ClusterClaim) bool {
+		// only check ClaimOCMProduct
+		if oldClaim.Name != ClaimOCMPlatform {
+			return true
+		}
+		// don't allow update from a specific value to "Other"
+		if newClaim.Spec.Value == PlatformOther {
+			return false
+		}
+		return true
+	},
+}
+
+func createOrUpdateClusterClaim(ctx context.Context, clusterClient clusterclientset.Interface,
+	newClaim *clusterv1alpha1.ClusterClaim,
+	updateChecks []updateCheck) error {
+	oldClaim, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(ctx, newClaim.Name, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
-		_, err := r.ClusterClient.ClusterV1alpha1().ClusterClaims().Create(ctx, newClaim, metav1.CreateOptions{})
+		_, err := clusterClient.ClusterV1alpha1().ClusterClaims().Create(ctx, newClaim, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create ClusterClaim: %v, %w", newClaim, err)
 		}
 	case err != nil:
 		return fmt.Errorf("unable to get ClusterClaim %q: %w", newClaim.Name, err)
 	case !reflect.DeepEqual(oldClaim.Spec, newClaim.Spec):
-		// if newClaim.Name is in clusterClaimCreateOnlyList, then do nothing
-		if utils.ContainsString(clusterClaimCreateOnlyList, newClaim.Name) && oldClaim.Spec.Value != "" {
-			return nil
+		if len(updateChecks) != 0 {
+			for _, check := range updateChecks {
+				if !check(oldClaim, newClaim) {
+					// not pass the check, skip update
+					return nil
+				}
+			}
 		}
 		oldClaim.Spec = newClaim.Spec
-		_, err := r.ClusterClient.ClusterV1alpha1().ClusterClaims().Update(ctx, oldClaim, metav1.UpdateOptions{})
+		_, err := clusterClient.ClusterV1alpha1().ClusterClaims().Update(ctx, oldClaim, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to update ClusterClaim %q: %w", oldClaim.Name, err)
 		}
 	}
 	return nil
+}
+
+func cleanClusterClaims(ctx context.Context, clusterClient clusterclientset.Interface,
+	currentClusterClaims, expectClusterClaims []*clusterv1alpha1.ClusterClaim) error {
+	errs := []error{}
+	expectSet := sets.Set[string]{}
+	for _, c := range expectClusterClaims {
+		expectSet.Insert(c.Name)
+	}
+	for _, c := range currentClusterClaims {
+		if expectSet.Has(c.Name) {
+			continue
+		}
+		err := clusterClient.ClusterV1alpha1().ClusterClaims().Delete(ctx, c.Name, metav1.DeleteOptions{})
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utils.NewMultiLineAggregate(errs)
 }

--- a/pkg/klusterlet/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaim_controller_test.go
@@ -2,40 +2,66 @@ package clusterclaim
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	clienttesting "k8s.io/client-go/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	clusterv1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
+	clusterv1alpha1lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1alpha1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 )
 
-func newClusterClaimReconciler(clusterClient clusterclientset.Interface, listFunc ListClusterClaimsFunc) *ClusterClaimReconciler {
-	return &ClusterClaimReconciler{
-		Log:               ctrl.Log.WithName("controllers").WithName("ManagedClusterInfo"),
-		ClusterClient:     clusterClient,
-		ListClusterClaims: listFunc,
+type fakeClusterClaimLister struct {
+	clusterClaims []*clusterv1alpha1.ClusterClaim
+}
+
+func (f *fakeClusterClaimLister) Get(name string) (*clusterv1alpha1.ClusterClaim, error) {
+	for _, c := range f.clusterClaims {
+		if c.Name == name {
+			return c, nil
+		}
+	}
+	return nil, errors.NewNotFound(clusterv1alpha1.Resource("clusterclaim"), name)
+}
+
+func (f *fakeClusterClaimLister) List(selector labels.Selector) (ret []*clusterv1alpha1.ClusterClaim, err error) {
+	for _, c := range f.clusterClaims {
+		if selector.Matches(labels.Set(c.Labels)) {
+			ret = append(ret, c)
+		}
+	}
+	return
+}
+
+func newFakeClusterClaimLister(clusterClaims []*clusterv1alpha1.ClusterClaim) clusterv1alpha1lister.ClusterClaimLister {
+	return &fakeClusterClaimLister{
+		clusterClaims: clusterClaims,
 	}
 }
 
 func TestCreateOrUpdate(t *testing.T) {
 	testcases := []struct {
-		name                       string
-		clusterClaimCreateOnlyList []string
-		objects                    []runtime.Object
-		clusterclaims              []*clusterv1alpha1.ClusterClaim
-		validateAddonActions       func(t *testing.T, actions []clienttesting.Action)
+		name                 string
+		objects              []runtime.Object
+		clusterclaims        []*clusterv1alpha1.ClusterClaim
+		validateAddonActions func(t *testing.T, actions []clienttesting.Action)
 	}{
 		{
-			name:                       "create cluster claim",
-			clusterClaimCreateOnlyList: []string{},
-			objects:                    []runtime.Object{},
+			name:    "create cluster claim",
+			objects: []runtime.Object{},
 			clusterclaims: []*clusterv1alpha1.ClusterClaim{
 				newClusterClaim("x", "y"),
 			},
@@ -49,8 +75,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:                       "update cluster claim",
-			clusterClaimCreateOnlyList: []string{},
+			name: "update cluster claim",
 			objects: []runtime.Object{
 				newClusterClaim("x", "y"),
 			},
@@ -67,16 +92,15 @@ func TestCreateOrUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:                       "update cluster claim with create only list with empty",
-			clusterClaimCreateOnlyList: []string{"x"},
-			objects:                    []runtime.Object{},
+			name:    "update cluster claim with create only list with empty",
+			objects: []runtime.Object{},
 			clusterclaims: []*clusterv1alpha1.ClusterClaim{
-				newClusterClaim("x", "y"),
-				newClusterClaim("x", "z"),
+				newClusterClaim(ClaimK8sID, "y"),
+				newClusterClaim(ClaimK8sID, "z"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 3 {
-					t.Errorf("Expect 3 actions, but got: %v", len(actions))
+					t.Errorf("Expect 3 actions, but got %d actions: %v", len(actions), actions)
 				}
 				if actions[0].GetVerb() != "get" {
 					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
@@ -90,20 +114,71 @@ func TestCreateOrUpdate(t *testing.T) {
 			},
 		},
 		{
-			name:                       "update cluster claim with create only list",
-			clusterClaimCreateOnlyList: []string{"x"},
+			name: "update cluster claim with create only list",
 			objects: []runtime.Object{
-				newClusterClaim("x", "y"),
+				newClusterClaim(ClaimK8sID, "y"),
 			},
 			clusterclaims: []*clusterv1alpha1.ClusterClaim{
-				newClusterClaim("x", "yy"),
+				newClusterClaim(ClaimK8sID, "yy"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
 				if len(actions) != 1 {
-					t.Errorf("Expect 3 actions, but got: %v", len(actions))
+					t.Errorf("Expect 1 actions, but got %d actions: %v", len(actions), actions)
 				}
 				if actions[0].GetVerb() != "get" {
 					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				}
+			},
+		},
+		{
+			name: "update with the product and platform turns from a specific value to 'Other'",
+			objects: []runtime.Object{
+				newClusterClaim(ClaimOCMProduct, ProductROSA),
+				newClusterClaim(ClaimOCMPlatform, PlatformAWS),
+			},
+			clusterclaims: []*clusterv1alpha1.ClusterClaim{
+				newClusterClaim(ClaimOCMProduct, ProductOther),
+				newClusterClaim(ClaimOCMPlatform, PlatformOther),
+			},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				// expect 2 'get' actions
+				if len(actions) != 2 {
+					t.Errorf("Expect 2 actions, but got %d actions: %v", len(actions), actions)
+				}
+				if actions[0].GetVerb() != "get" {
+					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				}
+				if actions[1].GetVerb() != "get" {
+					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				}
+			},
+		},
+		{
+			name: "update with the product and platform turns from 'Other' to another value",
+			objects: []runtime.Object{
+				newClusterClaim(ClaimOCMProduct, ProductOther),
+				newClusterClaim(ClaimOCMPlatform, PlatformOther),
+			},
+			clusterclaims: []*clusterv1alpha1.ClusterClaim{
+				newClusterClaim(ClaimOCMProduct, ProductROSA),
+				newClusterClaim(ClaimOCMPlatform, PlatformAWS),
+			},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				// expect 4 actions: get update get update
+				if len(actions) != 4 {
+					t.Errorf("Expect 3 actions, but got %d actions: %v", len(actions), actions)
+				}
+				if actions[0].GetVerb() != "get" {
+					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				}
+				if actions[1].GetVerb() != "update" {
+					t.Errorf("Expect action update, but got: %s", actions[1].GetVerb())
+				}
+				if actions[2].GetVerb() != "get" {
+					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				}
+				if actions[3].GetVerb() != "update" {
+					t.Errorf("Expect action update, but got: %s", actions[1].GetVerb())
 				}
 			},
 		},
@@ -112,9 +187,8 @@ func TestCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testcases {
 		clusterClient := clusterfake.NewSimpleClientset(tc.objects...)
-		reconciler := newClusterClaimReconciler(clusterClient, nil)
 		for _, cc := range tc.clusterclaims {
-			if err := reconciler.createOrUpdate(ctx, cc, tc.clusterClaimCreateOnlyList); err != nil {
+			if err := createOrUpdateClusterClaim(ctx, clusterClient, cc, updateChecks); err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 			}
 		}
@@ -122,35 +196,47 @@ func TestCreateOrUpdate(t *testing.T) {
 	}
 }
 
+var testClusterName = "test-cluster"
+
 func TestSyncClaims(t *testing.T) {
 	ctx := context.Background()
 	expected := []*clusterv1alpha1.ClusterClaim{
 		newClusterClaim("x", "1"),
 		newClusterClaim("y", "2"),
 		newClusterClaim("z", "3"),
+	}
+	current := []*clusterv1alpha1.ClusterClaim{
+		// Expect to be deleted after reconcile
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "o",
+				Name:   "hubManaged",
+				Labels: map[string]string{labelHubManaged: ""},
+			},
+		},
+		// Expect to be kept after reconcile
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "syncedLabel",
+				Labels: map[string]string{labelHubManaged: "", labelCustomizedOnly: ""},
 			},
 		},
 	}
 
-	deletedClaim := &clusterv1alpha1.ClusterClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "p",
-			Labels: map[string]string{labelHubManaged: ""},
-		},
-	}
-
-	clusterClient := clusterfake.NewSimpleClientset(deletedClaim)
-	reconciler := newClusterClaimReconciler(clusterClient, func() ([]*clusterv1alpha1.ClusterClaim, error) {
-		return expected, nil
-	})
+	clusterClient := clusterfake.NewSimpleClientset(current[0], current[1])
+	reconciler, _ := NewClusterClaimReconciler(
+		ctrl.Log,
+		testClusterName,
+		clusterClient,
+		fake.NewClientBuilder().Build(),
+		newFakeClusterClaimLister(current), func() ([]*clusterv1alpha1.ClusterClaim, error) {
+			return expected, nil
+		}, false)
 
 	if err := reconciler.syncClaims(ctx); err != nil {
 		t.Errorf("Failed to sync cluster claims: %v", err)
 	}
 
+	// Expect claims in 'expected' list are created or updated
 	for _, item := range expected {
 		claim, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(), item.Name, metav1.GetOptions{})
 		if err != nil {
@@ -162,9 +248,192 @@ func TestSyncClaims(t *testing.T) {
 		}
 	}
 
+	// Expect 'hubManaged' are deleted
 	if _, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(),
-		deletedClaim.Name, metav1.GetOptions{}); !errors.IsNotFound(err) {
-		t.Errorf("deleted cluster claim %v is not deleted", deletedClaim.Name)
+		"hubManaged", metav1.GetOptions{}); !errors.IsNotFound(err) {
+		t.Errorf("deleted cluster claim hubManaged is not deleted")
 	}
 
+	// Expect 'syncedLabel' are not deleted
+	if _, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(),
+		"syncedLabel", metav1.GetOptions{}); err != nil {
+		t.Errorf("get cluster claim syncedLabel err: %v", err)
+	}
+}
+
+func TestGenLabelsToClaims(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		claims []*clusterv1alpha1.ClusterClaim
+	}{
+		{
+			name: "no label",
+		},
+		{
+			name: "internal labels",
+			labels: map[string]string{
+				clusterv1beta1.LabelCloudVendor:     "a",
+				clusterv1beta1.LabelKubeVendor:      "b",
+				clusterv1beta1.LabelManagedBy:       "c",
+				clusterv1beta1.OCPVersion:           "d",
+				clusterv1beta1.OCPVersionMajor:      "4.x",
+				clusterv1beta1.OCPVersionMajorMinor: "4.x",
+			},
+			claims: []*clusterv1alpha1.ClusterClaim{
+				// ocpversionmajor and ocpversionmajorminor has been dependied by GRC, SD, and some customer TAMs. Should not be added into internalLabels set.
+				newClusterClaim(strings.ToLower(clusterv1beta1.OCPVersionMajor), "4.x"),
+				newClusterClaim(strings.ToLower(clusterv1beta1.OCPVersionMajorMinor), "4.x"),
+			},
+		},
+		{
+			name: "too long & empty value",
+			labels: map[string]string{
+				fmt.Sprintf("%s.com/xyz", strings.Repeat("x", 253)): "value",
+				"empty-label": "",
+			},
+		},
+		{
+			name: "with transformation",
+			labels: map[string]string{
+				"UPPERCASE":   "UPPERCASE",
+				"abc.com/def": "abc.com/def",
+				"abc/def/ghi": "abc/def/ghi",
+				"under_score": "under_score",
+			},
+			claims: []*clusterv1alpha1.ClusterClaim{
+				newClusterClaim("uppercase", "UPPERCASE"),
+				newClusterClaim("def.abc.com", "abc.com/def"),
+				newClusterClaim("abc.def.ghi", "abc/def/ghi"),
+				newClusterClaim("under-score", "under_score"),
+			},
+		},
+		{
+			name: "without transformation",
+			labels: map[string]string{
+				"label": "value",
+			},
+			claims: []*clusterv1alpha1.ClusterClaim{
+				newClusterClaim("label", "value"),
+			},
+		},
+		{
+			name: "contains 'open-cluster-management.io'",
+			labels: map[string]string{
+				"open-cluster-management.io/agent": "klusterlet",
+			},
+			claims: []*clusterv1alpha1.ClusterClaim{},
+		},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(clusterv1beta1.SchemeGroupVersion, &clusterv1beta1.ManagedClusterInfo{})
+	clusterv1beta1.AddToScheme(s)
+
+	clusterName := "test-cluster"
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hubClient := fake.NewClientBuilder().WithScheme(s).
+				WithRuntimeObjects(newFakeManagedClusterInfo(clusterName, test.labels)).Build()
+			actual, err := genLabelsToClaims(hubClient, clusterName)
+			assert.Equal(t, nil, err)
+			assert.Equal(t, len(test.claims), len(actual))
+			sort.SliceStable(test.claims, func(i, j int) bool { return test.claims[i].Name < test.claims[j].Name })
+			sort.SliceStable(actual, func(i, j int) bool { return actual[i].Name < actual[j].Name })
+			for i, claim := range test.claims {
+				assert.Equal(t, claim.Name, actual[i].Name)
+				assert.Equal(t, claim.Spec.Value, actual[i].Spec.Value)
+			}
+		})
+	}
+}
+
+func newFakeManagedClusterInfo(clusterName string, labels map[string]string) *clusterv1beta1.ManagedClusterInfo {
+	clusterInfo := &clusterv1beta1.ManagedClusterInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: clusterName,
+			Labels: map[string]string{
+				clusterv1beta1.LabelClusterID:   "1234",
+				clusterv1beta1.LabelCloudVendor: "AWS",
+				clusterv1beta1.LabelKubeVendor:  "OCP",
+			},
+		},
+	}
+	clusterInfo.SetLabels(labels)
+
+	return clusterInfo
+}
+
+func TestSyncLabelsToClaims(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	current := []*clusterv1alpha1.ClusterClaim{
+		// Expect to be kept after reconcile
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "hubManaged",
+				Labels: map[string]string{labelHubManaged: ""},
+			},
+		},
+		// Expect to be deleted after reconcile
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "syncedLabel",
+				Labels: map[string]string{labelHubManaged: "", labelCustomizedOnly: ""},
+			},
+		},
+	}
+
+	// Reconciler will get expected(wating for sync) claims from managed cluster info labels
+	managedClusterInfo := newFakeManagedClusterInfo(testClusterName, map[string]string{
+		"os": "linux", // expect to be created after the reconcile
+	})
+
+	s := scheme.Scheme
+	s.AddKnownTypes(clusterv1beta1.SchemeGroupVersion, &clusterv1beta1.ManagedClusterInfo{})
+	clusterv1beta1.AddToScheme(s)
+
+	// populate with the current claims
+	hubClient := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(managedClusterInfo).Build()
+	clusterClient := clusterfake.NewSimpleClientset(current[0], current[1])
+
+	reconciler, _ := NewClusterClaimReconciler(
+		ctrl.Log,
+		testClusterName,
+		clusterClient,
+		hubClient,
+		newFakeClusterClaimLister(current),
+		func() ([]*clusterv1alpha1.ClusterClaim, error) {
+			return current, nil
+		}, true)
+
+	if err != nil {
+		t.Errorf("Failed to create cluster claim reconciler: %v", err)
+		return
+	}
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+	if err != nil {
+		t.Errorf("Failed to sync cluster claims: %v", err)
+		return
+	}
+
+	// hubManaged should not be ignored
+	if _, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(),
+		"hubManaged", metav1.GetOptions{}); err != nil {
+		t.Errorf("get cluster claim hubManaged err: %v", err)
+	}
+
+	// syncedLabel should be deleted
+	if _, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(),
+		"syncedLabel", metav1.GetOptions{}); !errors.IsNotFound(err) {
+		t.Errorf("deleted cluster claim syncedLabel is not deleted")
+	}
+
+	// os should be created
+	if _, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(context.Background(),
+		"os", metav1.GetOptions{}); err != nil {
+		t.Errorf("get cluster claim os err: %v", err)
+	}
 }

--- a/pkg/klusterlet/clusterclaim/clusterclaimer_test.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaimer_test.go
@@ -1,9 +1,6 @@
 package clusterclaim
 
 import (
-	"fmt"
-	"sort"
-	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -14,7 +11,6 @@ import (
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	openshiftoauthclientset "github.com/openshift/client-go/oauth/clientset/versioned"
 	oauthfake "github.com/openshift/client-go/oauth/clientset/versioned/fake"
-	clusterv1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -23,11 +19,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/restmapper"
-	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func newClusterVersion() *apiconfigv1.ClusterVersion {
@@ -458,26 +450,6 @@ func newConfigmap(namespace, name string) *corev1.ConfigMap {
 	}
 }
 
-func fakeHubClient(clusterName string, labels map[string]string) client.Client {
-	clusterInfo := &clusterv1beta1.ManagedClusterInfo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: clusterName,
-			Labels: map[string]string{
-				clusterv1beta1.LabelClusterID:   "1234",
-				clusterv1beta1.LabelCloudVendor: "AWS",
-				clusterv1beta1.LabelKubeVendor:  "OCP",
-			},
-		},
-	}
-	clusterInfo.SetLabels(labels)
-	s := scheme.Scheme
-	s.AddKnownTypes(clusterv1beta1.SchemeGroupVersion, &clusterv1beta1.ManagedClusterInfo{})
-	clusterv1beta1.AddToScheme(s)
-
-	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterInfo).Build()
-}
-
 func newMicroShiftVersionConfigmap(version string) *corev1.ConfigMap {
 	configmap := newConfigmap("kube-public", "microshift-version")
 	configmap.Data = map[string]string{
@@ -488,28 +460,24 @@ func newMicroShiftVersionConfigmap(version string) *corev1.ConfigMap {
 
 func TestClusterClaimerList(t *testing.T) {
 	tests := []struct {
-		name                            string
-		clusterName                     string
-		hubClient                       client.Client
-		kubeClient                      kubernetes.Interface
-		configV1Client                  openshiftclientset.Interface
-		oauthV1Client                   openshiftoauthclientset.Interface
-		mapper                          meta.RESTMapper
-		enableSyncLabelsToClusterClaims bool
-		expectClaims                    map[string]string
-		expectErr                       error
+		name           string
+		clusterName    string
+		kubeClient     kubernetes.Interface
+		configV1Client openshiftclientset.Interface
+		oauthV1Client  openshiftoauthclientset.Interface
+		mapper         meta.RESTMapper
+		expectClaims   map[string]string
+		expectErr      error
 	}{
 		{
 			name:           "claims of OCP on AWS",
 			clusterName:    "clusterAWS",
-			hubClient:      fakeHubClient("clusterAWS", map[string]string{"testLabel/abc": "testLabel"}),
 			kubeClient:     newFakeKubeClient([]runtime.Object{newNode(PlatformAWS), newConfigmapConsoleConfig()}),
 			mapper:         newFakeRestMapper([]*restmapper.APIGroupResources{projectAPIGroupResources}),
 			configV1Client: newConfigV1Client("4.x", PlatformAWS),
 			oauthV1Client: newOauthV1Client([]string{
 				"https://oauth-openshift.apps.a.b.c.com/oauth/token/implicit",
 			}),
-			enableSyncLabelsToClusterClaims: true,
 			expectClaims: map[string]string{
 				ClaimK8sID:                      "clusterAWS",
 				ClaimOpenshiftVersion:           "4.6.8",
@@ -522,21 +490,18 @@ func TestClusterClaimerList(t *testing.T) {
 				ClaimOCMRegion:                  "region-aws",
 				ClaimControlPlaneTopology:       "HighlyAvailable",
 				ClaimOpenshiftOauthRedirectURIs: "https://oauth-openshift.apps.a.b.c.com/oauth/token/implicit",
-				"abc.testlabel":                 "testLabel",
 			},
 			expectErr: nil,
 		},
 		{
 			name:           "claims of OCP on AWS disable enableSyncLabelsToClusterClaims",
 			clusterName:    "clusterAWS",
-			hubClient:      fakeHubClient("clusterAWS", map[string]string{"testLabel/abc": "testLabel"}),
 			kubeClient:     newFakeKubeClient([]runtime.Object{newNode(PlatformAWS), newConfigmapConsoleConfig()}),
 			mapper:         newFakeRestMapper([]*restmapper.APIGroupResources{projectAPIGroupResources}),
 			configV1Client: newConfigV1Client("4.x", PlatformAWS),
 			oauthV1Client: newOauthV1Client([]string{
 				"https://oauth-openshift.apps.a.b.c.com/oauth/token/implicit",
 			}),
-			enableSyncLabelsToClusterClaims: false,
 			expectClaims: map[string]string{
 				ClaimK8sID:                      "clusterAWS",
 				ClaimOpenshiftVersion:           "4.6.8",
@@ -553,14 +518,13 @@ func TestClusterClaimerList(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:                            "claims of OSD on GCP",
-			clusterName:                     "clusterOSDGCP",
-			hubClient:                       fakeHubClient("clusterOSDGCP", map[string]string{"open-cluster-management.io/agent": "abc"}),
-			kubeClient:                      newFakeKubeClient([]runtime.Object{newNode(PlatformGCP), newConfigmapConsoleConfig()}),
-			mapper:                          newFakeRestMapper([]*restmapper.APIGroupResources{projectAPIGroupResources, osdAPIGroupResources}),
-			configV1Client:                  newConfigV1Client("4.x", PlatformGCP),
-			oauthV1Client:                   newOauthV1Client(nil),
-			enableSyncLabelsToClusterClaims: true,
+			name:           "claims of OSD on GCP",
+			clusterName:    "clusterOSDGCP",
+			kubeClient:     newFakeKubeClient([]runtime.Object{newNode(PlatformGCP), newConfigmapConsoleConfig()}),
+			mapper:         newFakeRestMapper([]*restmapper.APIGroupResources{projectAPIGroupResources, osdAPIGroupResources}),
+			configV1Client: newConfigV1Client("4.x", PlatformGCP),
+			oauthV1Client:  newOauthV1Client(nil),
+
 			expectClaims: map[string]string{
 				ClaimK8sID:                   "clusterOSDGCP",
 				ClaimOpenshiftVersion:        "4.6.8",
@@ -576,14 +540,12 @@ func TestClusterClaimerList(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name:                            "claims of non-OCP",
-			clusterName:                     "clusterNonOCP",
-			hubClient:                       fakeHubClient("clusterNonOCP", map[string]string{}),
-			kubeClient:                      newFakeKubeClient([]runtime.Object{newNode(PlatformGCP), newEndpoint()}),
-			mapper:                          newFakeRestMapper([]*restmapper.APIGroupResources{}),
-			configV1Client:                  newConfigV1Client("3", ""),
-			oauthV1Client:                   newOauthV1Client(nil),
-			enableSyncLabelsToClusterClaims: true,
+			name:           "claims of non-OCP",
+			clusterName:    "clusterNonOCP",
+			kubeClient:     newFakeKubeClient([]runtime.Object{newNode(PlatformGCP), newEndpoint()}),
+			mapper:         newFakeRestMapper([]*restmapper.APIGroupResources{}),
+			configV1Client: newConfigV1Client("3", ""),
+			oauthV1Client:  newOauthV1Client(nil),
 			expectClaims: map[string]string{
 				ClaimK8sID:          "clusterNonOCP",
 				ClaimOCMPlatform:    PlatformGCP,
@@ -595,14 +557,12 @@ func TestClusterClaimerList(t *testing.T) {
 		{
 			name:           "claims of IBM Cloud (ROKS)",
 			clusterName:    "clusterROKS",
-			hubClient:      fakeHubClient("clusterROKS", map[string]string{"testLabel/abc": "testLabel"}),
 			kubeClient:     newFakeKubeClient([]runtime.Object{newNode(PlatformIBM), newConfigmapConsoleConfig()}),
 			mapper:         newFakeRestMapper([]*restmapper.APIGroupResources{projectAPIGroupResources}),
 			configV1Client: newConfigV1Client("4.x", PlatformIBM),
 			oauthV1Client: newOauthV1Client([]string{
 				"https://oauth-openshift.apps.a.b.c.com/oauth/token/implicit",
 			}),
-			enableSyncLabelsToClusterClaims: true,
 			expectClaims: map[string]string{
 				ClaimK8sID:                      "clusterROKS",
 				ClaimOpenshiftVersion:           "4.6.8",
@@ -614,7 +574,6 @@ func TestClusterClaimerList(t *testing.T) {
 				ClaimOCMKubeVersion:             "v0.0.0-master+$Format:%H$",
 				ClaimControlPlaneTopology:       "HighlyAvailable",
 				ClaimOpenshiftOauthRedirectURIs: "https://oauth-openshift.apps.a.b.c.com/oauth/token/implicit",
-				"abc.testlabel":                 "testLabel",
 			},
 			expectErr: nil,
 		},
@@ -636,16 +595,14 @@ func TestClusterClaimerList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			clusterClaimer := ClusterClaimer{ClusterName: test.clusterName,
-				HubClient:                       test.hubClient,
-				KubeClient:                      test.kubeClient,
-				Mapper:                          test.mapper,
-				ConfigV1Client:                  test.configV1Client,
-				OauthV1Client:                   test.oauthV1Client,
-				managedclusterID:                test.clusterName,
-				EnableSyncLabelsToClusterClaims: test.enableSyncLabelsToClusterClaims,
+			clusterClaimer := ClusterClaimer{
+				KubeClient:       test.kubeClient,
+				Mapper:           test.mapper,
+				ConfigV1Client:   test.configV1Client,
+				OauthV1Client:    test.oauthV1Client,
+				managedclusterID: test.clusterName,
 			}
-			claims, err := clusterClaimer.List()
+			claims, err := clusterClaimer.GenerateExpectClusterClaims()
 			assert.Equal(t, test.expectErr, err)
 
 			assert.Equal(t, len(claims), len(test.expectClaims))
@@ -1181,86 +1138,10 @@ func TestUpdatePlatformProduct(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			clusterClaimer := ClusterClaimer{KubeClient: test.kubeClient, Mapper: test.mapper, ConfigV1Client: test.configV1Client}
-			err := clusterClaimer.updatePlatformProduct()
+			platform, product, err := clusterClaimer.getPlatformProduct()
 			assert.Equal(t, test.expectErr, err)
-			assert.Equal(t, test.expectPlatform, clusterClaimer.Platform)
-			assert.Equal(t, test.expectProduct, clusterClaimer.Product)
-		})
-	}
-}
-
-func TestSyncLabelsToClaims(t *testing.T) {
-	tests := []struct {
-		name   string
-		labels map[string]string
-		claims []*clusterv1alpha1.ClusterClaim
-	}{
-		{
-			name: "no label",
-		},
-		{
-			name: "internal labels",
-			labels: map[string]string{
-				clusterv1beta1.LabelCloudVendor:     "a",
-				clusterv1beta1.LabelKubeVendor:      "b",
-				clusterv1beta1.LabelManagedBy:       "c",
-				clusterv1beta1.OCPVersion:           "d",
-				clusterv1beta1.OCPVersionMajor:      "4.x",
-				clusterv1beta1.OCPVersionMajorMinor: "4.x",
-			},
-			claims: []*clusterv1alpha1.ClusterClaim{
-				// ocpversionmajor and ocpversionmajorminor has been dependied by GRC, SD, and some customer TAMs. Should not be added into internalLabels set.
-				newClusterClaim(strings.ToLower(clusterv1beta1.OCPVersionMajor), "4.x"),
-				newClusterClaim(strings.ToLower(clusterv1beta1.OCPVersionMajorMinor), "4.x"),
-			},
-		},
-		{
-			name: "too long & empty value",
-			labels: map[string]string{
-				fmt.Sprintf("%s.com/xyz", strings.Repeat("x", 253)): "value",
-				"empty-label": "",
-			},
-		},
-		{
-			name: "with transformation",
-			labels: map[string]string{
-				"UPPERCASE":   "UPPERCASE",
-				"abc.com/def": "abc.com/def",
-				"abc/def/ghi": "abc/def/ghi",
-				"under_score": "under_score",
-			},
-			claims: []*clusterv1alpha1.ClusterClaim{
-				newClusterClaim("uppercase", "UPPERCASE"),
-				newClusterClaim("def.abc.com", "abc.com/def"),
-				newClusterClaim("abc.def.ghi", "abc/def/ghi"),
-				newClusterClaim("under-score", "under_score"),
-			},
-		},
-		{
-			name: "without transformation",
-			labels: map[string]string{
-				"label": "value",
-			},
-			claims: []*clusterv1alpha1.ClusterClaim{
-				newClusterClaim("label", "value"),
-			},
-		},
-	}
-
-	clusterName := "test-cluster"
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			hubClient := fakeHubClient(clusterName, test.labels)
-			clusterClaimer := ClusterClaimer{HubClient: hubClient, ClusterName: clusterName}
-			actual, err := clusterClaimer.syncLabelsToClaims()
-			assert.Equal(t, nil, err)
-			assert.Equal(t, len(test.claims), len(actual))
-			sort.SliceStable(test.claims, func(i, j int) bool { return test.claims[i].Name < test.claims[j].Name })
-			sort.SliceStable(actual, func(i, j int) bool { return actual[i].Name < actual[j].Name })
-			for i, claim := range test.claims {
-				assert.Equal(t, claim.Name, actual[i].Name)
-				assert.Equal(t, claim.Spec.Value, actual[i].Spec.Value)
-			}
+			assert.Equal(t, test.expectPlatform, platform)
+			assert.Equal(t, test.expectProduct, product)
 		})
 	}
 }

--- a/pkg/klusterlet/clusterclaim/manager.go
+++ b/pkg/klusterlet/clusterclaim/manager.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	clusterv1alpha1informer "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1alpha1"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -17,18 +18,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func (r *ClusterClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *clusterClaimReconciler) SetupWithManager(mgr ctrl.Manager, clusterInformer clusterv1alpha1informer.ClusterClaimInformer) error {
 	// setup a controller for ClusterClaim with customized event source and handler
 	c, err := controller.New("ClusterClaim", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
 
-	claimSource := NewClusterClaimSource(r.ClusterInformers)
-	if err := c.Watch(claimSource, &ClusterClaimEventHandler{}); err != nil {
+	claimSource := NewClusterClaimSource(clusterInformer)
+	if err := c.Watch(claimSource, NewClusterClaimEventHandler()); err != nil {
 		return err
 	}
 
+	// There are 2 use cases for this watch:
+	// 1. when labels of the managedclusterinfo changed, we need to sync labels to clusterclaims
+	// 2. at the beginning of the pod, we need this watch to trigger the reconcile of all clusterclaims
 	if err := c.Watch(source.Kind(mgr.GetCache(), &clusterv1beta1.ManagedClusterInfo{}), &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
@@ -55,13 +59,20 @@ func (s *clusterClaimSource) Start(ctx context.Context, handler handler.EventHan
 	// all predicates are ignored
 	s.claimInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			handler.Create(ctx, event.CreateEvent{}, queue)
+			handler.Create(ctx, event.CreateEvent{
+				Object: obj.(*clusterv1alpha1.ClusterClaim),
+			}, queue)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			handler.Update(ctx, event.UpdateEvent{}, queue)
+			handler.Update(ctx, event.UpdateEvent{
+				ObjectOld: oldObj.(*clusterv1alpha1.ClusterClaim),
+				ObjectNew: newObj.(*clusterv1alpha1.ClusterClaim),
+			}, queue)
 		},
 		DeleteFunc: func(obj interface{}) {
-			handler.Delete(ctx, event.DeleteEvent{}, queue)
+			handler.Delete(ctx, event.DeleteEvent{
+				Object: obj.(*clusterv1alpha1.ClusterClaim),
+			}, queue)
 		},
 	})
 
@@ -76,22 +87,26 @@ func (s *clusterClaimSource) WaitForSync(ctx context.Context) error {
 }
 
 // ClusterClaimEventHandler maps any event to an empty request
-type ClusterClaimEventHandler struct{}
+func NewClusterClaimEventHandler() *clusterClaimEventHandler {
+	return &clusterClaimEventHandler{}
+}
 
-var _ handler.EventHandler = &ClusterClaimEventHandler{}
+type clusterClaimEventHandler struct{}
 
-func (e *ClusterClaimEventHandler) Create(_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+var _ handler.EventHandler = &clusterClaimEventHandler{}
+
+func (e *clusterClaimEventHandler) Create(_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request{})
 }
 
-func (e *ClusterClaimEventHandler) Update(_ context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e *clusterClaimEventHandler) Update(_ context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request{})
 }
 
-func (e *ClusterClaimEventHandler) Delete(_ context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (e *clusterClaimEventHandler) Delete(_ context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request{})
 }
 
-func (e *ClusterClaimEventHandler) Generic(_ context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (e *clusterClaimEventHandler) Generic(_ context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	q.Add(reconcile.Request{})
 }

--- a/pkg/klusterlet/clusterinfo/manager.go
+++ b/pkg/klusterlet/clusterinfo/manager.go
@@ -20,7 +20,7 @@ func (r *ClusterInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	claimSource := clusterclaim.NewClusterClaimSource(r.ClaimInformer)
 	nodeSource := &nodeSource{nodeInformer: r.NodeInformer.Informer()}
 	return ctrl.NewControllerManagedBy(mgr).
-		WatchesRawSource(claimSource, &clusterclaim.ClusterClaimEventHandler{}).
+		WatchesRawSource(claimSource, clusterclaim.NewClusterClaimEventHandler()).
 		WatchesRawSource(nodeSource, &nodeEventHandler{}).
 		For(&clusterv1beta1.ManagedClusterInfo{}).
 		Complete(r)


### PR DESCRIPTION
Fixes: 
* https://issues.redhat.com/browse/ACM-7497: The agent on the hosting cluster continuously deletes the synced label claims that created by the customer hub.
* https://issues.redhat.com/browse/ACM-7500:  When rosa-logo configmap is created after agent pods started, it can't be detected as rosa.