### PR TITLE
generate microshift cluster id

### DIFF
--- a/pkg/klusterlet/clusterinfo/defaultInfo_sync.go
+++ b/pkg/klusterlet/clusterinfo/defaultInfo_sync.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+
 	clusterv1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim"
 	"golang.org/x/net/context"
@@ -26,6 +27,8 @@ func (s *defaultInfoSyncer) sync(ctx context.Context, clusterInfo *clusterv1beta
 		case clusterclaim.ClaimOCMKubeVersion:
 			clusterInfo.Status.Version = value
 		case clusterclaim.ClaimOpenshiftID:
+			clusterInfo.Status.ClusterID = value
+		case clusterclaim.ClaimMicroShiftID:
 			clusterInfo.Status.ClusterID = value
 		case clusterclaim.ClaimOCMProduct:
 			clusterInfo.Status.KubeVendor = getKubeVendor(value)

--- a/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
+++ b/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,8 +12,6 @@ import (
 	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-	"testing"
-	"time"
 )
 
 func newClaim(name, value string) *clusterv1alpha1.ClusterClaim {
@@ -159,6 +160,28 @@ func Test_defaultInfo_syncer(t *testing.T) {
 					managedClusterInfo.Status.Version != "v1.20.0" ||
 					managedClusterInfo.Status.KubeVendor != v1beta1.KubeVendorOther ||
 					managedClusterInfo.Status.CloudVendor != v1beta1.CloudVendorIBMP {
+					t.Errorf("failed to validate defaut info")
+				}
+			},
+		},
+		{
+			name: "Microshift cluster",
+			claims: []runtime.Object{
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
+				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductMicroShift),
+				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformOther),
+				newClaim(clusterclaim.ClaimMicroShiftID, "aaa-bbb-ccc"),
+				newClaim(clusterclaim.ClaimMicroShiftVersion, "4.16.0"),
+			},
+			managedClusterInfo: &v1beta1.ManagedClusterInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
+			},
+			validate: func(managedClusterInfo *v1beta1.ManagedClusterInfo) {
+				if managedClusterInfo.Status.ClusterID != "aaa-bbb-ccc" ||
+					managedClusterInfo.Status.Version != "v1.20.0" ||
+					managedClusterInfo.Status.KubeVendor != v1beta1.KubeVendorMicroShift ||
+					managedClusterInfo.Status.CloudVendor != v1beta1.CloudVendorOther {
 					t.Errorf("failed to validate defaut info")
 				}
 			},


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-11167 
Testing result:
On microshift 
```
[root@rhel lib]# oc get clusterclaim
NAME                                     AGE
id.k8s.io                                2m36s
id.microshift.io                         2m36s
kubeversion.open-cluster-management.io   2m36s
name                                     2m36s
platform.open-cluster-management.io      2m36s
product.open-cluster-management.io       2m36s
schedulable.open-cluster-management.io   2m36s
version.microshift.io                    2m36s
```
On hub
```
apiVersion: cluster.open-cluster-management.io/v1
kind: ManagedCluster
metadata:
  annotations:
    open-cluster-management/created-via: other
  creationTimestamp: "2024-04-22T11:04:49Z"
  finalizers:
  - managedclusterinfo.finalizers.open-cluster-management.io
  - open-cluster-management.io/managedclusterrole
  - managedcluster-import-controller.open-cluster-management.io/cleanup
  - cluster.open-cluster-management.io/api-resource-cleanup
  - managedcluster-import-controller.open-cluster-management.io/manifestwork-cleanup
  generation: 3
  labels:
    cloud: Other
    cluster.open-cluster-management.io/clusterset: default
    clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
    feature.open-cluster-management.io/addon-cluster-proxy: unreachable
    feature.open-cluster-management.io/addon-managed-serviceaccount: available
    feature.open-cluster-management.io/addon-work-manager: unreachable
    microshiftVersion: 4.15.9
    name: cluster1
    vendor: MicroShift
  name: cluster1
  resourceVersion: "221861"
  uid: f273ba25-4e61-466a-988b-f9bf815182a6
spec:
  hubAcceptsClient: true
  leaseDurationSeconds: 60
status:
...
  clusterClaims:
  - name: id.k8s.io
    value: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
  - name: kubeversion.open-cluster-management.io
    value: v1.28.7
  - name: platform.open-cluster-management.io
    value: Other
  - name: product.open-cluster-management.io
    value: MicroShift
  - name: id.microshift.io
    value: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
  - name: schedulable.open-cluster-management.io
    value: "true"
  - name: version.microshift.io
    value: 4.15.9
```
```
apiVersion: internal.open-cluster-management.io/v1beta1
kind: ManagedClusterInfo
metadata:
  creationTimestamp: "2024-04-22T11:04:49Z"
  generation: 1
  labels:
    cloud: Other
    cluster.open-cluster-management.io/clusterset: default
    clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
    feature.open-cluster-management.io/addon-cluster-proxy: available
    feature.open-cluster-management.io/addon-managed-serviceaccount: available
    feature.open-cluster-management.io/addon-work-manager: available
    microshiftVersion: 4.15.9
    name: cluster1
    vendor: MicroShift
  name: cluster1
  namespace: cluster1
  resourceVersion: "222195"
  uid: 16b26175-8d1b-462b-ad3a-89f3aec40079
spec: {}
status:
  cloudVendor: Other
  clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
...
```
metrics
```
# TYPE acm_managed_cluster_info gauge
acm_managed_cluster_info{hub_cluster_id="ce9766a0-e599-4154-9ecb-3bb31999482d",managed_cluster_id="ce9766a0-e599-4154-9ecb-3bb31999482d",vendor="OpenShift",cloud="Amazon",service_name="Other",version="4.14.3",available="True",created_via="Other",core_worker="8",socket_worker="1",hub_type="acm"} 1
acm_managed_cluster_info{hub_cluster_id="ce9766a0-e599-4154-9ecb-3bb31999482d",managed_cluster_id="0e581b5f-98e1-4a2a-9dc9-d9d555fd665c",vendor="MicroShift",cloud="Other",service_name="Other",version="v1.28.7",available="True",created_via="Other",core_worker="4",socket_worker="0",hub_type="acm"} 1
```
