### PR TITLE
use clusterclaim id.k8s.io as cluster ID for non-ocp clusters

### DIFF
--- a/pkg/klusterlet/clusterinfo/defaultInfo_sync.go
+++ b/pkg/klusterlet/clusterinfo/defaultInfo_sync.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+
 	clusterv1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim"
 	"golang.org/x/net/context"
@@ -25,8 +26,14 @@ func (s *defaultInfoSyncer) sync(ctx context.Context, clusterInfo *clusterv1beta
 			clusterInfo.Status.ConsoleURL = value
 		case clusterclaim.ClaimOCMKubeVersion:
 			clusterInfo.Status.Version = value
+		// use id.openshift.io as cluster ID for ocp clusters
 		case clusterclaim.ClaimOpenshiftID:
 			clusterInfo.Status.ClusterID = value
+		// use id.k8s.io as cluster ID for non-ocp clusters
+		case clusterclaim.ClaimK8sID:
+			if clusterInfo.Status.ClusterID == "" {
+				clusterInfo.Status.ClusterID = value
+			}
 		case clusterclaim.ClaimOCMProduct:
 			clusterInfo.Status.KubeVendor = getKubeVendor(value)
 		case clusterclaim.ClaimOCMPlatform:

--- a/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
+++ b/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,8 +12,6 @@ import (
 	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-	"testing"
-	"time"
 )
 
 func newClaim(name, value string) *clusterv1alpha1.ClusterClaim {
@@ -39,6 +40,7 @@ func Test_defaultInfo_syncer(t *testing.T) {
 				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductOpenShift),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformAWS),
 				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb-ccc"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
@@ -60,7 +62,7 @@ func Test_defaultInfo_syncer(t *testing.T) {
 				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
 				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductAKS),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformAzure),
-				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
@@ -82,7 +84,7 @@ func Test_defaultInfo_syncer(t *testing.T) {
 				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
 				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductGKE),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformGCP),
-				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
@@ -104,6 +106,7 @@ func Test_defaultInfo_syncer(t *testing.T) {
 				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
 				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductOSD),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformIBM),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
 				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
@@ -126,7 +129,7 @@ func Test_defaultInfo_syncer(t *testing.T) {
 				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
 				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductIKS),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformOpenStack),
-				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
@@ -142,13 +145,34 @@ func Test_defaultInfo_syncer(t *testing.T) {
 			},
 		},
 		{
+			name: "Microshift cluster",
+			claims: []runtime.Object{
+				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
+				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductMicroShift),
+				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformOther),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimMicroShiftVersion, "4.16.0"),
+			},
+			managedClusterInfo: &v1beta1.ManagedClusterInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
+			},
+			validate: func(managedClusterInfo *v1beta1.ManagedClusterInfo) {
+				if managedClusterInfo.Status.ClusterID != "aaa-bbb" ||
+					managedClusterInfo.Status.Version != "v1.20.0" ||
+					managedClusterInfo.Status.KubeVendor != v1beta1.KubeVendorMicroShift ||
+					managedClusterInfo.Status.CloudVendor != v1beta1.CloudVendorOther {
+					t.Errorf("failed to validate defaut info")
+				}
+			},
+		},
+		{
 			name: "Other cluster",
 			claims: []runtime.Object{
 				newClaim(clusterclaim.ClaimOCMConsoleURL, "https://abc.com"),
 				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
 				newClaim(clusterclaim.ClaimOCMProduct, "test"),
 				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformIBMP),
-				newClaim(clusterclaim.ClaimOpenshiftID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
 			},
 			managedClusterInfo: &v1beta1.ManagedClusterInfo{
 				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-11167
