### PR TITLE
use id.k8s.io as MicroShift cluster ID

### DIFF
--- a/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
+++ b/pkg/klusterlet/clusterinfo/defaultInfo_sync_test.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/klusterlet/clusterclaim"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,8 +12,6 @@ import (
 	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-	"testing"
-	"time"
 )
 
 func newClaim(name, value string) *clusterv1alpha1.ClusterClaim {
@@ -137,6 +138,27 @@ func Test_defaultInfo_syncer(t *testing.T) {
 					managedClusterInfo.Status.Version != "v1.20.0" ||
 					managedClusterInfo.Status.KubeVendor != v1beta1.KubeVendorIKS ||
 					managedClusterInfo.Status.CloudVendor != v1beta1.CloudVendorOpenStack {
+					t.Errorf("failed to validate defaut info")
+				}
+			},
+		},
+		{
+			name: "Microshift cluster",
+			claims: []runtime.Object{
+				newClaim(clusterclaim.ClaimOCMKubeVersion, "v1.20.0"),
+				newClaim(clusterclaim.ClaimOCMProduct, clusterclaim.ProductMicroShift),
+				newClaim(clusterclaim.ClaimOCMPlatform, clusterclaim.PlatformOther),
+				newClaim(clusterclaim.ClaimK8sID, "aaa-bbb"),
+				newClaim(clusterclaim.ClaimMicroShiftVersion, "4.16.0"),
+			},
+			managedClusterInfo: &v1beta1.ManagedClusterInfo{
+				ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "c1"},
+			},
+			validate: func(managedClusterInfo *v1beta1.ManagedClusterInfo) {
+				if managedClusterInfo.Status.ClusterID != "aaa-bbb" ||
+					managedClusterInfo.Status.Version != "v1.20.0" ||
+					managedClusterInfo.Status.KubeVendor != v1beta1.KubeVendorMicroShift ||
+					managedClusterInfo.Status.CloudVendor != v1beta1.CloudVendorOther {
 					t.Errorf("failed to validate defaut info")
 				}
 			},


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/ACM-11167
Testing result:
On microshift
```
[root@rhel cloud-user]# oc get clusterclaim
NAME                                     AGE
id.k8s.io                                47m
kubeversion.open-cluster-management.io   47m
name                                     47m
platform.open-cluster-management.io      47m
product.open-cluster-management.io       47m
schedulable.open-cluster-management.io   47m
version.microshift.io                    47m
```
On hub
```
apiVersion: cluster.open-cluster-management.io/v1
kind: ManagedCluster
metadata:
  annotations:
    open-cluster-management/created-via: other
...
  labels:
    cloud: Other
    cluster.open-cluster-management.io/clusterset: default
    clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
    feature.open-cluster-management.io/addon-cluster-proxy: available
    feature.open-cluster-management.io/addon-managed-serviceaccount: available
    feature.open-cluster-management.io/addon-work-manager: available
    microshiftVersion: 4.15.9
    name: cluster1
    vendor: MicroShift
  name: cluster1
  resourceVersion: "126136"
  uid: 9fd2b809-8d97-4e93-891a-94de5f7d6cc5
spec:
  hubAcceptsClient: true
  leaseDurationSeconds: 60
status:
...
  clusterClaims:
  - name: id.k8s.io
    value: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
  - name: kubeversion.open-cluster-management.io
    value: v1.28.7
  - name: platform.open-cluster-management.io
    value: Other
  - name: product.open-cluster-management.io
    value: MicroShift
  - name: schedulable.open-cluster-management.io
    value: "true"
  - name: version.microshift.io
    value: 4.15.9
```
```
apiVersion: internal.open-cluster-management.io/v1beta1
kind: ManagedClusterInfo
metadata:
  creationTimestamp: "2024-05-06T06:17:37Z"
  generation: 1
  labels:
    cloud: Other
    cluster.open-cluster-management.io/clusterset: default
    clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
    feature.open-cluster-management.io/addon-cluster-proxy: available
    feature.open-cluster-management.io/addon-managed-serviceaccount: available
    feature.open-cluster-management.io/addon-work-manager: available
    microshiftVersion: 4.15.9
    name: cluster1
    vendor: MicroShift
  name: cluster1
  namespace: cluster1
  resourceVersion: "126137"
  uid: 77757c65-b638-470b-90e8-1541baebccd9
spec:
  loggingCA:=
status:
  cloudVendor: Other
  clusterID: 0e581b5f-98e1-4a2a-9dc9-d9d555fd665c
```
metrics
```
# TYPE acm_managed_cluster_info gauge
acm_managed_cluster_info{hub_cluster_id="c1106834-ab98-43a1-8ba2-0ab68acbbf5f",managed_cluster_id="0e581b5f-98e1-4a2a-9dc9-d9d555fd665c",vendor="MicroShift",cloud="Other",service_name="Other",version="v1.28.7",available="True",created_via="Other",core_worker="4",socket_worker="0",hub_type="acm"} 1
acm_managed_cluster_info{hub_cluster_id="c1106834-ab98-43a1-8ba2-0ab68acbbf5f",managed_cluster_id="c1106834-ab98-43a1-8ba2-0ab68acbbf5f",vendor="OpenShift",cloud="Amazon",service_name="Other",version="4.14.3",available="True",created_via="Other",core_worker="16",socket_worker="1",hub_type="acm"} 1
```