### PR TITLE
Fix: e2e fail in get pod log, using `main` tag instead of `latest` of cluster-proxy images.

### DIFF
--- a/deploy/managedcluster/addons/install.sh
+++ b/deploy/managedcluster/addons/install.sh
@@ -61,8 +61,8 @@ BASEDDOMAIN=$($KUBECTL get ingress.config.openshift.io cluster -o=jsonpath='{.sp
 	-n open-cluster-management --create-namespace \
 	cluster-proxy-addon chart/cluster-proxy-addon \
 	--set global.pullPolicy=Always \
-	--set global.imageOverrides.cluster_proxy_addon="${CLUSTER_PROXY_ADDON_IMAGE}:latest" \
-	--set global.imageOverrides.cluster_proxy="${IMAGE_CLUSTER_PROXY}:latest" \
+	--set global.imageOverrides.cluster_proxy_addon="${CLUSTER_PROXY_ADDON_IMAGE}:main" \
+	--set global.imageOverrides.cluster_proxy="${IMAGE_CLUSTER_PROXY}:main" \
 	--set cluster_basedomain="${BASEDDOMAIN}"
 if [ $? -eq 1 ]; then
   echo "failed to install cluster-proxy addon"


### PR DESCRIPTION
In quay.io  https://quay.io/repository/stolostron/cluster-proxy?tab=tags , I find the `latest` of cluster-proxy is the same with backplane-2.4 which is too old to use in e2e test.

![image](https://github.com/stolostron/multicloud-operators-foundation/assets/11444421/fbb63974-e9f6-410f-881d-2f6e830824bf)

So changed to use `main`.

Fixes: https://issues.redhat.com/browse/ACM-11089
