### PR TITLE
update ocp version if there is only 1 history item in clusterVersion

### DIFF
--- a/pkg/klusterlet/clusterclaim/clusterclaimer.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaimer.go
@@ -335,6 +335,10 @@ func (c *ClusterClaimer) getOCPVersion() (version, clusterID string, err error) 
 	clusterID = string(clusterVersion.Spec.ClusterID)
 	historyItems := clusterVersion.Status.History
 
+	if len(historyItems) == 1 {
+		return historyItems[0].Version, clusterID, nil
+	}
+
 	var latestCompleteTime *metav1.Time
 	var latestCompleteVersion string
 


### PR DESCRIPTION
issue : will not get the OCP version to the clusterClaim when the history items in the clusterversion only has 1 item and the status is not Completed.
fix: get the OCP version if the history items in the clusterversion only has 1 item, will not check if the item is Completed.