### PR TITLE
Remove depracated `randdom.Seed` function

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -4,9 +4,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/stolostron/multicloud-operators-foundation/cmd/controller/app"
 	"github.com/stolostron/multicloud-operators-foundation/cmd/controller/app/options"
@@ -23,8 +21,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	s := options.NewControllerRunOptions()

--- a/cmd/proxyserver/proxyserver.go
+++ b/cmd/proxyserver/proxyserver.go
@@ -4,9 +4,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stolostron/multicloud-operators-foundation/cmd/proxyserver/app"
@@ -22,8 +20,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	opts := options.NewOptions()

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -4,9 +4,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stolostron/multicloud-operators-foundation/cmd/webhook/app"
@@ -20,8 +18,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	opts := options.NewOptions()


### PR DESCRIPTION
After go 1.20, this call is not nessary:

```
Deprecated: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator.
```