### PR TITLE
Update using err not `obj == nil` to determine get result.

### DIFF
--- a/pkg/controllers/clusterset/syncclusterrolebinding/syncclusterrolebinding_controller_test.go
+++ b/pkg/controllers/clusterset/syncclusterrolebinding/syncclusterrolebinding_controller_test.go
@@ -115,11 +115,14 @@ func TestSyncManagedClusterClusterroleBinding(t *testing.T) {
 	}
 }
 
-func validateResult(t *testing.T, caseName string, r *Reconciler, clusterrolebindingName string, exist bool) {
-	ctx := context.Background()
-	clusterrolebinding, _ := r.kubeClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterrolebindingName, metav1.GetOptions{})
-	if exist && clusterrolebinding == nil {
-		t.Errorf("Case: %v, Failed to apply clusterrolebinding", caseName)
+func validateResult(t *testing.T, caseName string, r *Reconciler, clusterrolebindingName string, expectedExist bool) {
+	if !expectedExist {
+		return // no need to check
+	}
+
+	_, err := r.kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), clusterrolebindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Case: %v, Failed to get clusterrolebinding, err: %v", caseName, err)
 	}
 }
 

--- a/pkg/controllers/clusterset/syncrolebinding/syncrolebinding_controller_test.go
+++ b/pkg/controllers/clusterset/syncrolebinding/syncrolebinding_controller_test.go
@@ -119,10 +119,12 @@ func TestSyncManagedClusterClusterroleBinding(t *testing.T) {
 	}
 }
 
-func validateResult(t *testing.T, r *Reconciler, managedclusterName string, exist bool) {
-	ctx := context.Background()
-	managedclusterRolebinding, _ := r.kubeClient.RbacV1().RoleBindings(managedclusterName).Get(ctx, utils.GenerateClustersetResourceRoleBindingName("admin"), metav1.GetOptions{})
-	if exist && managedclusterRolebinding == nil {
-		t.Errorf("Failed to apply managedclusterRolebinding")
+func validateResult(t *testing.T, r *Reconciler, managedclusterName string, expectExist bool) {
+	if !expectExist {
+		return // no need to validate
+	}
+	_, err := r.kubeClient.RbacV1().RoleBindings(managedclusterName).Get(context.Background(), utils.GenerateClustersetResourceRoleBindingName("admin"), metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("rolebinding %s should be exist, but got error: %v", utils.GenerateClustersetResourceRoleBindingName("admin"), err)
 	}
 }


### PR DESCRIPTION
In latest version of controller-runtime pkgs, when obj is not found, the result obj is not nil, so change to using err to determine the result to be more accurate.