### PR TITLE
Add a new annotation to control whether sycn labels to clusterclaims.

### DIFF
--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stolostron/cluster-lifecycle-api/helpers/imageregistry"
+	"github.com/stolostron/multicloud-operators-foundation/pkg/constants"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -75,6 +76,10 @@ func NewGetValuesFunc(imageName string) addonfactory.GetValuesFunc {
 		if value, ok := addon.GetAnnotations()[addonapiv1alpha1.HostingClusterNameAnnotationKey]; ok && value != "" {
 			enableSyncLabelsToClusterClaims = false
 			enableNodeCapacity = false
+		}
+		// TODO: @xuezhaojun using this new annotation replace the addonapiv1alpha1.HostingClusterNameAnnotationKey.
+		if syncLabelsToClusterClaims, ok := cluster.GetAnnotations()[constants.SyncLabelsToClusterClaimsAnnotation]; ok {
+			enableSyncLabelsToClusterClaims = syncLabelsToClusterClaims == "true"
 		}
 
 		addonValues := Values{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,4 +14,7 @@ const (
 	// GlobalNamespaceAnnotation is the annotation on the global managed cluster set. If the cluster set has
 	// this annotation, the related ns/binding/placement will not be created.
 	GlobalNamespaceAnnotation = "open-cluster-management.io/ns-create"
+
+	// SyncLabelsToClusterClaimsAnnotation is the annotation to control whether sync labels to cluster claims.
+	SyncLabelsToClusterClaimsAnnotation = "open-cluster-management.io/sync-labels-to-clusterclaims"
 )


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ACM-14178

Test image: [quay.io/zhaoxue/multicloud-manager:new-annotation-917-01](http://quay.io/zhaoxue/multicloud-manager:new-annotation-917-01)

In the global hub case, it has 2 default mode agents sync labels from 2 hub clusters. We need to add a control to disable one of them.