### PR TITLE
🐛 Stop adding managed cluster label for the namespace

### DIFF
--- a/pkg/controllers/clusterrole/clusterrole_controller.go
+++ b/pkg/controllers/clusterrole/clusterrole_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stolostron/multicloud-operators-foundation/pkg/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -20,7 +19,6 @@ import (
 
 const (
 	clusterRoleFinalizerName = "open-cluster-management.io/managedclusterrole"
-	managedClusterKey        = "cluster.open-cluster-management.io/managedCluster"
 )
 
 type Reconciler struct {
@@ -125,25 +123,5 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// add label to clusternamespace
-	clusterNamespace, err := r.kubeClient.CoreV1().Namespaces().Get(context.TODO(), cluster.Name, metav1.GetOptions{})
-	if err != nil {
-		klog.Warningf("will reconcile since failed get clusternamespace %v, %v", cluster.Name, err)
-		return ctrl.Result{}, err
-	}
-
-	var ClusterNameLabel = map[string]string{
-		managedClusterKey: cluster.GetName(),
-	}
-	var modified = false
-	utils.MergeMap(&modified, &clusterNamespace.Labels, ClusterNameLabel)
-
-	if modified {
-		_, err = r.kubeClient.CoreV1().Namespaces().Update(context.TODO(), clusterNamespace, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Warningf("will reconcile since failed update clusternamespace %v, %v", cluster.Name, err)
-			return ctrl.Result{}, err
-		}
-	}
 	return ctrl.Result{}, nil
 }

--- a/test/e2e/managedcluster_test.go
+++ b/test/e2e/managedcluster_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stolostron/multicloud-operators-foundation/pkg/utils"
 	"github.com/stolostron/multicloud-operators-foundation/test/e2e/util"
 	e2eutil "github.com/stolostron/multicloud-operators-foundation/test/e2e/util"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -224,102 +223,103 @@ var _ = ginkgo.Describe("Testing ManagedCluster", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 		})
 
-		ginkgo.It("Check if admin/view clusterrole could be recreated after delete it", func() {
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// ginkgo.It("Check if admin/view clusterrole could be recreated after delete it", func() {
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-			err := kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), adminClusterClusterRoleName, metav1.DeleteOptions{})
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			err = kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), viewClusterClusterRoleName, metav1.DeleteOptions{})
-			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 	err := kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), adminClusterClusterRoleName, metav1.DeleteOptions{})
+		// 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		// 	err = kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), viewClusterClusterRoleName, metav1.DeleteOptions{})
+		// 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-		})
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// })
 
-		ginkgo.It("Check if admin clusterrole could be reconcile after update it", func() {
-			gomega.Eventually(func() error {
-				adminClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				updatedAdminClusterRole := adminClusterRole.DeepCopy()
-				updatedAdminClusterRole.Rules = []v1.PolicyRule{}
-				updatedAdminClusterRole, err = kubeClient.RbacV1().ClusterRoles().Update(context.Background(), updatedAdminClusterRole, metav1.UpdateOptions{})
-				if err != nil {
-					return err
-				}
-				gomega.Eventually(func() error {
-					updatedAdminClusterRole, err = kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-					if err != nil {
-						return err
-					}
-					if len(updatedAdminClusterRole.Rules) == len(adminClusterRole.Rules) {
-						return nil
-					}
-					return fmt.Errorf("The admin clusterrole should be reconciled. updatedAdminClusterRole: %v,adminClusterRole: %v", updatedAdminClusterRole, adminClusterRole)
-				}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-				return nil
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// ginkgo.It("Check if admin clusterrole could be reconcile after update it", func() {
+		// 	gomega.Eventually(func() error {
+		// 		adminClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 		if err != nil {
+		// 			return err
+		// 		}
+		// 		updatedAdminClusterRole := adminClusterRole.DeepCopy()
+		// 		updatedAdminClusterRole.Rules = []v1.PolicyRule{}
+		// 		updatedAdminClusterRole, err = kubeClient.RbacV1().ClusterRoles().Update(context.Background(), updatedAdminClusterRole, metav1.UpdateOptions{})
+		// 		if err != nil {
+		// 			return err
+		// 		}
+		// 		gomega.Eventually(func() error {
+		// 			updatedAdminClusterRole, err = kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 			if err != nil {
+		// 				return err
+		// 			}
+		// 			if len(updatedAdminClusterRole.Rules) == len(adminClusterRole.Rules) {
+		// 				return nil
+		// 			}
+		// 			return fmt.Errorf("The admin clusterrole should be reconciled. updatedAdminClusterRole: %v,adminClusterRole: %v", updatedAdminClusterRole, adminClusterRole)
+		// 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 		return nil
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-		})
-		ginkgo.It("Check if view clusterrole could be reconcile after update it", func() {
-			gomega.Eventually(func() error {
-				viewClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				updatedViewClusterRole := viewClusterRole.DeepCopy()
-				updatedViewClusterRole.Rules = []v1.PolicyRule{}
-				updatedViewClusterRole, err = kubeClient.RbacV1().ClusterRoles().Update(context.Background(), updatedViewClusterRole, metav1.UpdateOptions{})
-				if err != nil {
-					return err
-				}
-				gomega.Eventually(func() error {
-					updatedViewClusterRole, err = kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-					if err != nil {
-						return err
-					}
-					if len(updatedViewClusterRole.Rules) == len(viewClusterRole.Rules) {
-						return nil
-					}
-					return fmt.Errorf("The admin clusterrole should be reconciled. updatedViewClusterRole: %v,viewClusterRole: %v", updatedViewClusterRole, viewClusterRole)
-				}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-				return nil
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// })
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// ginkgo.It("Check if view clusterrole could be reconcile after update it", func() {
+		// 	gomega.Eventually(func() error {
+		// 		viewClusterRole, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
+		// 		if err != nil {
+		// 			return err
+		// 		}
+		// 		updatedViewClusterRole := viewClusterRole.DeepCopy()
+		// 		updatedViewClusterRole.Rules = []v1.PolicyRule{}
+		// 		updatedViewClusterRole, err = kubeClient.RbacV1().ClusterRoles().Update(context.Background(), updatedViewClusterRole, metav1.UpdateOptions{})
+		// 		if err != nil {
+		// 			return err
+		// 		}
+		// 		gomega.Eventually(func() error {
+		// 			updatedViewClusterRole, err = kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 			if err != nil {
+		// 				return err
+		// 			}
+		// 			if len(updatedViewClusterRole.Rules) == len(viewClusterRole.Rules) {
+		// 				return nil
+		// 			}
+		// 			return fmt.Errorf("The admin clusterrole should be reconciled. updatedViewClusterRole: %v,viewClusterRole: %v", updatedViewClusterRole, viewClusterRole)
+		// 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// 		return nil
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			gomega.Eventually(func() error {
-				_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
-				return err
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-		})
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), adminClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+		// 	gomega.Eventually(func() error {
+		// 		_, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), viewClusterClusterRoleName, metav1.GetOptions{})
+		// 		return err
+		// 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		// })
 
 	})
 })


### PR DESCRIPTION
Stop adding managed cluster label for the namespace because import-controller already has [the same logic](https://github.com/stolostron/managedcluster-import-controller/blob/f9a6e8d5e9b9dec24eb2cd2129dacc30efb232a7/pkg/controller/managedcluster/managedcluster_controller.go#L98-L104)

Fix https://issues.redhat.com/browse/ACM-14616