### PR TITLE
Refactor: change to use the same kustomize as ocm and other repos do.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,13 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/imagebuilder.mk \
 	targets/openshift/images.mk \
 	targets/openshift/bindata.mk \
+	targets/openshift/kustomize.mk \
 	lib/tmp.mk \
 )
 
 # Tools for deploy
 KUBECONFIG ?= ./.kubeconfig
 KUBECTL?=kubectl
-KUSTOMIZE?=$(PERMANENT_TMP_GOPATH)/bin/kustomize
-KUSTOMIZE_VERSION?=v3.5.4
-KUSTOMIZE_ARCHIVE_NAME?=kustomize_$(KUSTOMIZE_VERSION)_$(GOHOSTOS)_$(GOHOSTARCH).tar.gz
-kustomize_dir:=$(dir $(KUSTOMIZE))
 
 HELM?=$(PERMANENT_TMP_GOPATH)/bin/helm
 HELM_VERSION?=v3.14.0
@@ -147,18 +144,6 @@ ifeq "" "$(wildcard $(KUBEBUILDER_ASSETS))"
 	tar -C '$(KUBEBUILDER_ASSETS)' --strip-components=2 -zvxf '$(KB_TOOLS_ARCHIVE_PATH)'
 else
 	$(info Using existing kube-apiserver from "$(KUBEBUILDER_ASSETS)")
-endif
-
-# Ensure kustomize
-ensure-kustomize:
-ifeq "" "$(wildcard $(KUSTOMIZE))"
-	$(info Installing kustomize into '$(KUSTOMIZE)')
-	mkdir -p '$(kustomize_dir)'
-	curl -s -f -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F$(KUSTOMIZE_VERSION)/$(KUSTOMIZE_ARCHIVE_NAME) -o '$(kustomize_dir)$(KUSTOMIZE_ARCHIVE_NAME)'
-	tar -C '$(kustomize_dir)' -zvxf '$(kustomize_dir)$(KUSTOMIZE_ARCHIVE_NAME)'
-	chmod +x '$(KUSTOMIZE)';
-else
-	$(info Using existing kustomize from "$(KUSTOMIZE)")
 endif
 
 ensure-helm:


### PR DESCRIPTION
The old `ensure-kustomize` does't support run e2e on macos:
```
curl -s -f -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_darwin_arm64.tar.gz -o '_output/tools/bin/kustomize_v3.5.4_darwin_arm64.tar.gz'
make: *** [ensure-kustomize] Error 56
```

The result of change:
```
➜  multicloud-operators-foundation git:(refactor-ensure-kustomize) make ensure-kustomize
vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk:21: warning: overriding commands for target `ensure-imagebuilder'
vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk:21: warning: ignoring old commands for target `ensure-imagebuilder'
Installing kustomize into '_output/tools/bin/kustomize-4.1.3'
mkdir -p '_output/tools/bin/'
rm -f _output/tools/bin//kustomize
curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v4.1.3/hack/install_kustomize.sh"  | bash -s 4.1.3 _output/tools/bin/
{Version:kustomize/v4.1.3 GitCommit:0f614e92f72f1b938a9171b964d90b197ca8fb68 BuildDate:2021-05-20T20:52:40Z GoOs:darwin GoArch:amd64}
kustomize installed to /Users/zxue/workspaces/multicloud-operators-foundation/_output/tools/bin/kustomize
mv _output/tools/bin//kustomize _output/tools/bin/kustomize-4.1.3
```