### PR TITLE
Fix: e2e fail -- cluster-proxy-addon log fail.

### DIFF
--- a/deploy/managedcluster/addons/install.sh
+++ b/deploy/managedcluster/addons/install.sh
@@ -79,6 +79,9 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
+# The cluster-proxy-proxy-agent deployment in open-cluster-management-agent-addon namespace should be ready
+$KUBECTL wait --for=condition=Ready -n open-cluster-management-agent-addon deployment/cluster-proxy-proxy-agent --timeout=120s
+
 cd ../ || exist
 rm -rf cluster-proxy-addon
 


### PR DESCRIPTION
Fix the following error:

```
Testing Pod log [It] should get log from pod successfully
/go/src/github.com/stolostron/multicloud-operators-foundation/test/e2e/log_test.go:94
  [FAILED] Timed out after 300.001s.
  Unexpected error:
      <*errors.StatusError | 0xc000741040>: 
      the server rejected our request for an unknown reason (get clusterstatuses.proxy.open-cluster-management.io cluster1)
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "the server rejected our request for an unknown reason (get clusterstatuses.proxy.open-cluster-management.io cluster1)",
              Reason: "BadRequest",
              Details: {
                  Name: "cluster1",
                  Group: "proxy.open-cluster-management.io",
                  Kind: "clusterstatuses",
                  UID: "",
                  Causes: [
                      {
                          Type: "UnexpectedServerResponse",
                          Message: "faield to stream log. an error on the server (\"proxy to anp-proxy-server failed because No agent available\") has prevented the request from succeeding (get pods klusterlet-agent-6657f45bf7-c7sm6)",
                          Field: "",
                      },
                  ],
                  RetryAfterSeconds: 0,
              },
              Code: 400,
          },
      }
  occurred
  In [It] at: /go/src/github.com/stolostron/multicloud-operators-foundation/test/e2e/log_test.go:116 @ 11/12/24 08:54:20.599
```