### PR TITLE
The konflux dockerfile has a mix or rhel9 and rhel8

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -6,7 +6,7 @@ ENV GO_PACKAGE github.com/stolostron/multicloud-operators-foundation
 RUN make build --warn-undefined-variables
 RUN make build-e2e --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=10001 \
     USER_NAME=acm-foundation


### PR DESCRIPTION
The go build uses rhel9 and the runtime tries to run it with rhel8 This results in errors running the binary due to glibc incompatible

Refs:
 - https://issues.redhat.com/browse/ACM-20018