### PR TITLE
Change `any` to * in list kubevirt projects api

### DIFF
--- a/docs/clusterview/clusterview.md
+++ b/docs/clusterview/clusterview.md
@@ -289,7 +289,7 @@ The `kubevirtprojects.clusterview.open-cluster-management.io` API is only used t
     cluster2   kubevirt-workspace-2
     ```
 
-**Note**: If using ClusterRoleBinding in ClusterPermission to bind a kubevirt ClusterRole, this API will return `any` in project field, for example:
+**Note**: If using ClusterRoleBinding in ClusterPermission to bind a kubevirt ClusterRole, this API will return `*` in project field, for example:
 
 ```yaml
 apiVersion: rbac.open-cluster-management.io/v1alpha1
@@ -329,7 +329,7 @@ spec:
 kubectl get kubevirtprojects.clusterview.open-cluster-management.io
 
 CLUSTER    PROJECT
-cluster1   any
-cluster2   any
+cluster1   *
+cluster2   *
 ```
 

--- a/pkg/proxyserver/rest/project/list.go
+++ b/pkg/proxyserver/rest/project/list.go
@@ -44,7 +44,7 @@ func listProjects(namespace, name string, obj runtime.Object, userInfo user.Info
 			}
 
 			if isKubeVirtRole(roleName) {
-				projects = append(projects, projectView{name: "any", cluster: namespace})
+				projects = append(projects, projectView{name: "*", cluster: namespace})
 				return projects
 			}
 		}


### PR DESCRIPTION
Change `any` to `*` in the kubevirtprojects api response to avoid potential issues if a project is named "any" in the managed cluster.

/assign @skeeey 