### PR TITLE
Upgrade Hive APIs to master branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openshift/api v0.0.0-20250313134101-8a7efbfb5316
 	github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52
 	github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87
-	github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2
+	github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921
 	github.com/openshift/library-go v0.0.0-20240621150525-4bb4238aef81
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/common v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52 h1:bq
 github.com/openshift/build-machinery-go v0.0.0-20240419090851-af9c868bcf52/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2 h1:VG1I5oBdVQl31Ic5aXL/1KnqIHe1/jwJxYoPNvx73II=
-github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2/go.mod h1:XUEuhGkTuSXP+eb0LtY3/iJTs/3Fc18CVkqMsmgN+gg=
+github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921 h1:qywdEth3yvx3ATrUq5OSlgD2sdfYKpsNQMkRcGHfR2Y=
+github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921/go.mod h1:XUEuhGkTuSXP+eb0LtY3/iJTs/3Fc18CVkqMsmgN+gg=
 github.com/openshift/library-go v0.0.0-20240621150525-4bb4238aef81 h1:cAo++YCkjrClksMEAPqK9SLMCroqlbGxNTluxeKGIGc=
 github.com/openshift/library-go v0.0.0-20240621150525-4bb4238aef81/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/openshift/client-go/route/clientset/versioned/fake
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1/fake
-# github.com/openshift/hive/apis v0.0.0-20250529232658-13b99a5eb2a2
+# github.com/openshift/hive/apis v0.0.0-20250820185956-bd9fd44f4921
 ## explicit; go 1.23.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
## Summary
- Updated github.com/openshift/hive/apis dependency from v0.0.0-20250529232658-13b99a5eb2a2 to v0.0.0-20250820185956-bd9fd44f4921
- Executed go mod tidy and go mod vendor to update dependencies
- Verified build and test compatibility

## Test plan
- [x] Build tests pass with `make build`
- [x] Unit tests pass for core functionality
- [x] Dependency resolution successful

🤖 Generated with [Claude Code](https://claude.ai/code)