### PR TITLE
fix: add ManagedCluster owner reference to RoleBinding

### DIFF
--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -670,7 +670,7 @@ func TestCreateOrUpdateRoleBinding(t *testing.T) {
 			}
 			opt := NewRegistrationOption(kubeClient, kubeInformers.Rbac().V1().RoleBindings(), "work-manager")
 			err := opt.PermissionConfig(
-				&clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: test.clusterName}},
+				&clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: test.clusterName, UID: "test-uid"}},
 				&addonapiv1alpha1.ManagedClusterAddOn{ObjectMeta: metav1.ObjectMeta{Name: "work-manager"}},
 			)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Related Jira: https://issues.redhat.com/browse/ACM-23613
- Set ManagedCluster as owner reference when creating RoleBinding in addon permission config
- Ensures RoleBinding is automatically deleted when ManagedCluster is removed
- Prevents orphaned RoleBinding resources

## Changes Made
- Modified `createOrUpdateRoleBinding` function signature to accept `*clusterv1.ManagedCluster` instead of cluster name string
- Added owner reference setting before RoleBinding creation
- Updated function call site to pass ManagedCluster object
- Updated tests to include UID for proper owner reference functionality

## Verified Result
```shell
oc apply -f mc-test.yaml 
managedcluster.cluster.open-cluster-management.io/test created

oc get rolebinding -n test
NAME                                                               ROLE                                                              AGE
cluster-proxy-addon-agent                                          Role/cluster-proxy-addon-agent                                    15s
managed-cluster-workmgr                                            ClusterRole/managed-cluster-workmgr                               16s
open-cluster-management:managed-serviceaccount:clusterrole:agent   ClusterRole/managed-serviceaccount-addon-agent                    15s
open-cluster-management:managedcluster:test:registration           ClusterRole/open-cluster-management:managedcluster:registration   15s
open-cluster-management:managedcluster:test:work                   ClusterRole/open-cluster-management:managedcluster:work           15s
system:deployers                                                   ClusterRole/system:deployer                                       15s
system:image-builders                                              ClusterRole/system:image-builder                                  15s
system:image-pullers                                               ClusterRole/system:image-puller                                   15s

oc annotate ns test "open-cluster-management.io/retain-namespace="
namespace/test annotated

oc delete managedcluster test
managedcluster.cluster.open-cluster-management.io "test" deleted

oc get rolebinding -n test
NAME                    ROLE                               AGE
system:deployers        ClusterRole/system:deployer        70s
system:image-builders   ClusterRole/system:image-builder   70s
system:image-pullers    ClusterRole/system:image-puller    70s
```

🤖 Generated with [Claude Code](https://claude.ai/code)