### PR TITLE
fix: prioritize infra role over worker in isWorker node classification

### DIFF
--- a/pkg/controllers/clusterinfo/capacity_controller.go
+++ b/pkg/controllers/clusterinfo/capacity_controller.go
@@ -99,22 +99,33 @@ func (r *CapacityReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	return ctrl.Result{}, r.client.Status().Update(ctx, cluster)
 }
 
-// for OCP,the master and infra nodes are not included in the subscription cost calculation.
-// the worker nodes are include the nodes with worker label or without controlPlane or infra label.
+// for OCP, the master and infra nodes are not included in the subscription cost calculation.
+// A node is NOT a worker if it has the infra role label, even if it also has the worker label.
+// A node with both control-plane/master and worker labels (e.g. SNO) IS counted as a worker.
+// A node with no recognized role labels is treated as a worker.
 func isWorker(node clusterinfov1beta1.NodeStatus) bool {
 	if node.Labels == nil {
 		return true
 	}
 
-	isControlPlane := false
-	for key := range node.Labels {
-		switch key {
-		case LabelNodeRoleWorker:
-			return true
-		case LabelNodeRoleOldControlPlane, LabelNodeRoleControlPlane, LabelNodeRoleInfra:
-			isControlPlane = true
-		}
+	// Infra role takes priority: infra nodes are never counted as workers,
+	// even if they also carry the worker role label.
+	if _, ok := node.Labels[LabelNodeRoleInfra]; ok {
+		return false
 	}
 
-	return !isControlPlane
+	_, hasWorker := node.Labels[LabelNodeRoleWorker]
+	if hasWorker {
+		return true
+	}
+
+	// If the node has control-plane or master labels (without worker), it's not a worker.
+	_, hasControlPlane := node.Labels[LabelNodeRoleControlPlane]
+	_, hasMaster := node.Labels[LabelNodeRoleOldControlPlane]
+	if hasControlPlane || hasMaster {
+		return false
+	}
+
+	// No recognized role labels — treat as worker.
+	return true
 }

--- a/pkg/controllers/clusterinfo/capacity_controller_test.go
+++ b/pkg/controllers/clusterinfo/capacity_controller_test.go
@@ -194,6 +194,30 @@ func Test_IsWorker(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "infra node with worker label",
+			node: clusterv1beta1.NodeStatus{
+				Name:   "",
+				Labels: map[string]string{LabelNodeRoleInfra: "", LabelNodeRoleWorker: ""},
+			},
+			expected: false,
+		},
+		{
+			name: "control-plane node",
+			node: clusterv1beta1.NodeStatus{
+				Name:   "",
+				Labels: map[string]string{LabelNodeRoleControlPlane: ""},
+			},
+			expected: false,
+		},
+		{
+			name: "worker only",
+			node: clusterv1beta1.NodeStatus{
+				Name:   "",
+				Labels: map[string]string{LabelNodeRoleWorker: ""},
+			},
+			expected: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `isWorker()` to exclude infra nodes from worker core count, even when they also carry the `node-role.kubernetes.io/worker` label
- The original code iterated over map keys and returned `true` immediately upon seeing the worker label, ignoring the infra label entirely — this caused inflated Worker core counts on the Overview page
- Use direct map lookups (O(1)) instead of map iteration, checking infra label first for correct priority
- SNO nodes (master + worker) are still correctly counted as workers
- Added 3 new test cases covering the bug scenario and edge cases

Ref: https://redhat.atlassian.net/browse/ACM-32488

## Test plan

- [ ] Existing `Test_IsWorker` cases pass (no label, SNO, no worker label, infra node)
- [ ] New test case: infra node with worker label → `false`
- [ ] New test case: control-plane only → `false`
- [ ] New test case: worker only → `true`
- [ ] Verify on a cluster with infra nodes (infra+worker labels) that Overview Worker core count excludes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)