### PR TITLE
Update OWNERS reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,12 @@
 reviewers:
-- ldpliu
-- qiujian16
-- zhiweiyin318
-- zhujian7
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
 
 approvers:
-- ldpliu
-- qiujian16
-- zhiweiyin318
-- zhujian7
-# Temporary approvers for facilitating prow configuration updates in the release repo during Konflux migration
-# These will be removed after the migration is complete
-- xuezhaojun
-- zhujian7
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+


### PR DESCRIPTION
Updates `OWNERS` so reviewers and approvers are: dhaiducek, tesshuflower, rokej, mikeshng.

Targets `backplane-2.17`. Same change as main.

Signed-off-by: Roke Jung <roke@redhat.com>

Made with [Cursor](https://cursor.com)