### PR TITLE
Update OWNERS reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,12 @@
 reviewers:
-- ldpliu
-- qiujian16
-- zhiweiyin318
-- zhujian7
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
 
 approvers:
-- ldpliu
-- qiujian16
-- zhiweiyin318
-- zhujian7
+- dhaiducek
+- tesshuflower
+- rokej
+- mikeshng
+


### PR DESCRIPTION
Updates `OWNERS` so reviewers and approvers are: dhaiducek, tesshuflower, rokej, mikeshng.

Targets `backplane-2.9`. Same change as main.

Signed-off-by: Roke Jung <roke@redhat.com>

Made with [Cursor](https://cursor.com)