### PR TITLE
Fix e2e so we can pass in branch name in CI

### DIFF
--- a/deploy/managedcluster/addons/install.sh
+++ b/deploy/managedcluster/addons/install.sh
@@ -65,7 +65,7 @@ oc apply -f https://raw.githubusercontent.com/stolostron/cluster-proxy/$OCM_BRAN
 	cluster-proxy-addon pkg/templates/charts/toggle/cluster-proxy-addon \
   --set global.namespace=open-cluster-management \
 	--set global.pullPolicy=Always \
-	--set global.imageOverrides.cluster_proxy="${IMAGE_CLUSTER_PROXY}:main" \
+	--set global.imageOverrides.cluster_proxy="${IMAGE_CLUSTER_PROXY}:${OCM_BRANCH}" \
 	--set hubconfig.clusterIngressDomain="${BASEDDOMAIN}"
 if [ $? -eq 1 ]; then
   echo "failed to install cluster-proxy addon"


### PR DESCRIPTION
- We previously fixed the CI e2e jobs (https://github.com/openshift/release/pull/79263) to pass in either the correct image:tag, or for other images such as these ones in deploy/managedcluster/addons/install.sh (which already specify the stolostron version of images), we set OCM_BRANCH.

- However cluster-proxy is using hardcoded "main" in the e2e install script rather than the provided OCM_BRANCH - which means e2e tests are always picking the latest cluster-proxy image (with `main` tag).
