### PR TITLE
Add FIPS build flags to Konflux Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/stolostron/multicloud-operators-foundation
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/multicloud-operators-foundation
 
-RUN XDG_CACHE_HOME=/tmp/cache make build --warn-undefined-variables
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime XDG_CACHE_HOME=/tmp/cache make build --warn-undefined-variables
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Apply CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to the multicloud-manager Konflux build for FIPS-compliant binaries.

JIRA: HYPBLD-844