### PR TITLE
fix: implement ConvertToTable for clusterstatuses API

### DIFF
--- a/pkg/proxyserver/api/register.go
+++ b/pkg/proxyserver/api/register.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stolostron/multicloud-operators-foundation/pkg/cache"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/cache/userpermission"
+	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/printers"
+	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/printers/storage"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/rest/log"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/rest/managedcluster"
 	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/rest/managedclusterset"
@@ -140,14 +142,20 @@ func installProxyGroup(proxyServiceInfoGetter *getter.ProxyServiceInfoGetter,
 	server *genericapiserver.GenericAPIServer) error {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(proxyv1beta1.GroupName, Scheme, ParameterCodec, Codecs)
 	apiGroupInfo.VersionedResourcesStorageMap[proxyv1beta1.SchemeGroupVersion.Version] = map[string]rest.Storage{
-		"clusterstatuses":            &clusterStatusStorage{},
+		"clusterstatuses": &clusterStatusStorage{
+			tableConverter: storage.TableConvertor{
+				TableGenerator: printers.NewTableGenerator().With(addClusterStatusHandlers),
+			},
+		},
 		"clusterstatuses/aggregator": proxy.NewProxyRest(proxyServiceInfoGetter),
 		"clusterstatuses/log":        log.NewLogRest(logProxyGetter),
 	}
 	return server.InstallAPIGroup(&apiGroupInfo)
 }
 
-type clusterStatusStorage struct{}
+type clusterStatusStorage struct {
+	tableConverter rest.TableConvertor
+}
 
 var (
 	_ = rest.Storage(&clusterStatusStorage{})
@@ -192,10 +200,38 @@ func (s *clusterStatusStorage) NamespaceScoped() bool {
 }
 
 func (s *clusterStatusStorage) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
-	return nil, nil
+	return s.tableConverter.ConvertToTable(ctx, object, tableOptions)
 }
 
 // SingularNameProvider interface
 func (s *clusterStatusStorage) GetSingularName() string {
 	return "clusterstatus"
+}
+
+func addClusterStatusHandlers(h printers.PrintHandler) {
+	columnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: "Name of the cluster status."},
+	}
+	_ = h.TableHandler(columnDefinitions, printClusterStatus)
+	_ = h.TableHandler(columnDefinitions, printClusterStatusList)
+}
+
+func printClusterStatus(obj *proxyv1beta1.ClusterStatus, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	row := metav1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells = append(row.Cells, obj.Name)
+	return []metav1.TableRow{row}, nil
+}
+
+func printClusterStatusList(list *proxyv1beta1.ClusterStatusList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	rows := make([]metav1.TableRow, 0, len(list.Items))
+	for i := range list.Items {
+		r, err := printClusterStatus(&list.Items[i], options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
 }

--- a/pkg/proxyserver/api/register_test.go
+++ b/pkg/proxyserver/api/register_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	proxyv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/apis/proxy/v1beta1"
+	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/printers"
+	"github.com/stolostron/multicloud-operators-foundation/pkg/proxyserver/printers/storage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestClusterStatusStorage() *clusterStatusStorage {
+	return &clusterStatusStorage{
+		tableConverter: storage.TableConvertor{
+			TableGenerator: printers.NewTableGenerator().With(addClusterStatusHandlers),
+		},
+	}
+}
+
+func TestConvertToTable_ClusterStatus(t *testing.T) {
+	s := newTestClusterStatusStorage()
+	obj := &proxyv1beta1.ClusterStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke-1"},
+	}
+
+	table, err := s.ConvertToTable(context.TODO(), obj, &metav1.TableOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if table == nil {
+		t.Fatal("expected non-nil table")
+	}
+	if len(table.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[0] != "spoke-1" {
+		t.Errorf("expected cell value 'spoke-1', got %v", table.Rows[0].Cells[0])
+	}
+}
+
+func TestConvertToTable_ClusterStatusList(t *testing.T) {
+	s := newTestClusterStatusStorage()
+	obj := &proxyv1beta1.ClusterStatusList{
+		Items: []proxyv1beta1.ClusterStatus{
+			{ObjectMeta: metav1.ObjectMeta{Name: "cluster-a"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "cluster-b"}},
+		},
+	}
+
+	table, err := s.ConvertToTable(context.TODO(), obj, &metav1.TableOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if table == nil {
+		t.Fatal("expected non-nil table")
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[0] != "cluster-a" {
+		t.Errorf("expected cell value 'cluster-a', got %v", table.Rows[0].Cells[0])
+	}
+	if table.Rows[1].Cells[0] != "cluster-b" {
+		t.Errorf("expected cell value 'cluster-b', got %v", table.Rows[1].Cells[0])
+	}
+}
+
+func TestConvertToTable_EmptyList(t *testing.T) {
+	s := newTestClusterStatusStorage()
+	obj := &proxyv1beta1.ClusterStatusList{}
+
+	table, err := s.ConvertToTable(context.TODO(), obj, &metav1.TableOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if table == nil {
+		t.Fatal("expected non-nil table")
+	}
+	if len(table.Rows) != 0 {
+		t.Fatalf("expected 0 rows, got %d", len(table.Rows))
+	}
+}


### PR DESCRIPTION
Wire up table conversion for the ClusterStatus proxy resource so that `kubectl get clusterstatuses` returns a proper table instead of nil. Add unit tests for single object, list, and empty list cases.

Assisted-by: Claude Code:claude-opus-4-6

I was experimenting with cluster-proxy and MCE 2.1.11 in OpenShift. I had one spoke-1 cluster registered (via UI) using kubeconfig. When I called `oc get clusterstatus` in the Hub, the ocm-proxy panicked with:

```
E0605 08:32:00.666081       1 runtime.go:140] "Observed a panic" panic=<
	runtime error: invalid memory address or nil pointer dereference
	goroutine 739 [running]:
	k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1()
		k8s.io/apiserver@v0.34.2/pkg/server/filters/timeout.go:110 +0xb0
	panic({0x282cb80?, 0x4abb490?})
		runtime/panic.go:783 +0x132
	k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x31a4ad0, 0xc000a8b8f0}, {0x317a1f8, 0xc0004aa5b0}, 0xc0018bdec0, 0xc0009361a0, {{0xc000f2ea31, 0xb}, {0xc000f2ea2c, 0x2}})
		k8s.io/apiserver@v0.34.2/pkg/endpoints/handlers/response.go:383 +0x22d
	k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x31a4ad0, 0xc000a8b8f0}, {0x317a1f8, 0xc0004aa5b0}, {0x2c53dc0, 0xc0018bdec0}, 0xc000a8ba10, 0xc0009361a0)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/handlers/response.go:271 +0x205
	k8s.io/apiserver/pkg/endpoints/handlers.transformResponseObject.func1()
		k8s.io/apiserver@v0.34.2/pkg/endpoints/handlers/response.go:335 +0x4d
	k8s.io/apiserver/pkg/endpoints/request.(*durationTracker).Track(0xc000bb5890, 0xc000a75e60)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/request/webhook_duration.go:75 +0x73
	k8s.io/apiserver/pkg/endpoints/request.TrackTransformResponseObjectLatency({0x31a4ad0?, 0xc000a8b8f0?}, 0xc000a75e60)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/request/webhook_duration.go:216 +0x5d
	k8s.io/apiserver/pkg/endpoints/handlers.transformResponseObject({0x31a4ad0, 0xc000a8b8f0}, 0xc0009361a0, 0xc000a9b400, {0x319ef00, 0xc000c6b9a0}, _, {0x0, {0x0, 0x0}, ...}, ...)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/handlers/response.go:337 +0x2b9
	k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1({0x319ef00, 0xc000c6b9a0}, 0xc000a8f540)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/handlers/get.go:309 +0x12fe
	k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.restfulListResource.func6(0xc000c6b980, 0xc0004aa540)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/installer.go:1294 +0x5f
	k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.InstrumentRouteFunc.func7(0xc000c6b980, 0xc0004aa540)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/metrics/metrics.go:645 +0x1c8
	github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc00083c5a0, {0x31a1630, 0xc0018bd8c0}, 0xc000a8f540)
		github.com/emicklei/go-restful/v3@v3.12.2/container.go:299 +0x9b7
	github.com/emicklei/go-restful/v3.(*Container).Dispatch(...)
		github.com/emicklei/go-restful/v3@v3.12.2/container.go:204
	k8s.io/apiserver/pkg/server.director.ServeHTTP({{0x2d2a3db?, 0x237311e?}, 0xc00083c5a0?, 0xc0003703f0?}, {0x31a1630, 0xc0018bd8c0}, 0xc000a8f540)
		k8s.io/apiserver@v0.34.2/pkg/server/handler.go:145 +0x588
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func22({0x31a1630, 0xc0018bd8c0}, 0xc000a8f540)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
	net/http.HandlerFunc.ServeHTTP(0x31a4ad0?, {0x31a1630?, 0xc0018bd8c0?}, 0x4?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1({0x31a1630, 0xc0018bd8c0}, 0xc000a8f540)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filters/authorization.go:84 +0x65a
	net/http.HandlerFunc.ServeHTTP(0xb9203c6fe?, {0x31a1630?, 0xc0018bd8c0?}, 0x2d2c349?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x31a1630, 0xc0018bd8c0}, 0xc000a8f400)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
	net/http.HandlerFunc.ServeHTTP(0x4ae93c0?, {0x31a1630?, 0xc0018bd8c0?}, 0x7f71f40257b8?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server/filters.WithMaxInFlightLimit.func1({0x31a1630, 0xc0018bd8c0}, 0xc000a8f400)
		k8s.io/apiserver@v0.34.2/pkg/server/filters/maxinflight.go:196 +0x254
	net/http.HandlerFunc.ServeHTTP(0x1eff30f?, {0x31a1630?, 0xc0018bd8c0?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func24({0x31a1630, 0xc0018bd8c0}, 0xc000a8f400)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
	net/http.HandlerFunc.ServeHTTP(0xc000bb5c20?, {0x31a1630?, 0xc0018bd8c0?}, 0x1744b2f2b7a3d7f9?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithImpersonation.func4({0x31a1630, 0xc0018bd8c0}, 0xc000a8f400)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filters/impersonation.go:50 +0x1b0
	net/http.HandlerFunc.ServeHTTP(0x0?, {0x31a1630?, 0xc0018bd8c0?}, 0x2d2c356?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x31a1630, 0xc0018bd8c0}, 0xc000a8f2c0)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
	net/http.HandlerFunc.ServeHTTP(0x1eff30f?, {0x31a1630?, 0xc0018bd8c0?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func25({0x31a1630, 0xc0018bd8c0}, 0xc000a8f2c0)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
	net/http.HandlerFunc.ServeHTTP(0x467b71?, {0x31a1630?, 0xc0018bd8c0?}, 0x2d1f1cf?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x31a1630, 0xc0018bd8c0}, 0xc000a8f180)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
	net/http.HandlerFunc.ServeHTTP(0x31a4ad0?, {0x31a1630?, 0xc0018bd8c0?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filters.WithTracing.func2({0x31a1630, 0xc0018bd8c0}, 0xc000a8f040)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filters/traces.go:62 +0x597
	net/http.HandlerFunc.ServeHTTP(0x31a4ad0?, {0x31a1630?, 0xc0018bd8c0?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc000173000, {0x319ef00, 0xc000c6b540}, 0xc000a8edc0, {0x316cd40, 0xc0006044f8})
		go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.61.0/handler.go:180 +0x1303
	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x319ef00?, 0xc000c6b540?}, 0x18a3f?)
		go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.61.0/handler.go:67 +0x35
	net/http.HandlerFunc.ServeHTTP(0x1eff30f?, {0x319ef00?, 0xc000c6b540?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func27({0x319ef00, 0xc000c6b540}, 0xc000a8edc0)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
	net/http.HandlerFunc.ServeHTTP(0x31a4ad0?, {0x319ef00?, 0xc000c6b540?}, 0x315f510?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x319ef00, 0xc000c6b540}, 0xc000a8edc0)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filters/authentication.go:123 +0x87f
	net/http.HandlerFunc.ServeHTTP(0x31a4ad0?, {0x319ef00?, 0xc000c6b540?}, 0x31646f0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x319ef00, 0xc000c6b540}, 0xc000a8eb40)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
	net/http.HandlerFunc.ServeHTTP(0xc000a8ea00?, {0x319ef00?, 0xc000c6b540?}, 0xc00067f770?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWarningRecorder.func11({0x319ef00, 0xc000c6b540}, 0xc000a8ea00)
		k8s.io/apiserver@v0.34.2/pkg/endpoints/filters/warning.go:35 +0xb9
	net/http.HandlerFunc.ServeHTTP(0xc001a0efd0?, {0x319ef00?, 0xc000c6b540?}, 0xc001a0efd0?)
		net/http/server.go:2322 +0x29
	k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()
		k8s.io/apiserver@v0.34.2/pkg/server/filters/timeout.go:115 +0x5b
	created by k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP in goroutine 738
		k8s.io/apiserver@v0.34.2/pkg/server/filters/timeout.go:101 +0x198
```
