### PR TITLE
update to golang1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 WORKDIR /go/src/github.com/stolostron/multicloud-operators-foundation
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/multicloud-operators-foundation

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 WORKDIR /go/src/github.com/stolostron/multicloud-operators-foundation
 COPY . .
 ENV GO_PACKAGE github.com/stolostron/multicloud-operators-foundation

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -12,7 +12,6 @@ ENV USER_UID=10001 \
 
 LABEL \
     name="multicluster-engine/multicloud-manager-rhel9" \
-    cpe="cpe:/a:redhat:multicluster_engine:2.11::el9" \
     com.redhat.component="multicloud-operators-foundation" \
     description="Stolostron Foundation supports some foundational components based ManagedCluster for \
     MultiCluster Engine (MCE) and Advanced Cluster Management (ACM)." \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/multicloud-operators-foundation
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Also removes the old incorrect cpe value from Dockerfile.rhap - the cpe label will be inserted automatically by the common pipeline.