### PR TITLE
ACM-37873: Add opt-in NetworkPolicy for work-manager addon agent

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -20,6 +20,7 @@ type ControllerRunOptions struct {
 	RenewDeadline         time.Duration
 	RetryPeriod           time.Duration
 	EnableAddonDeploy     bool
+	EnableNetworkPolicies bool
 	AddonImage            string
 	AddonInstallNamespace string
 	QPS                   float32
@@ -35,6 +36,7 @@ func NewControllerRunOptions() *ControllerRunOptions {
 		EnableInventory:       true,
 		EnableLeaderElection:  true,
 		EnableAddonDeploy:     false,
+		EnableNetworkPolicies: false,
 		EnableRBAC:            true,
 		QPS:                   100.0,
 		Burst:                 200,
@@ -73,6 +75,8 @@ func (o *ControllerRunOptions) AddFlags(fs *pflag.FlagSet) {
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.BoolVar(&o.EnableAddonDeploy, "enable-agent-deploy", o.EnableAddonDeploy,
 		"Enable deploy addon agent.")
+	fs.BoolVar(&o.EnableNetworkPolicies, "enable-network-policies", o.EnableNetworkPolicies,
+		"Enable NetworkPolicy for the work-manager addon agent on managed clusters.")
 	fs.StringVar(&o.AddonImage, "agent-addon-image", o.AddonImage,
 		"image of the addon agent to deploy.")
 	fs.StringVar(&o.AddonInstallNamespace, "agent-addon-install-namespace", o.AddonInstallNamespace,

--- a/cmd/controller/app/server.go
+++ b/cmd/controller/app/server.go
@@ -159,7 +159,7 @@ func Run(o *options.ControllerRunOptions, ctx context.Context) error {
 			WithConfigGVRs(afutils.AddOnDeploymentConfigGVR).
 			WithAgentDeployTriggerClusterFilter(afutils.ClusterImageRegistriesAnnotationChanged).
 			WithGetValuesFuncs(
-				addon.NewGetValuesFunc(o.AddonImage),
+				addon.NewGetValuesFunc(o.AddonImage, o.EnableNetworkPolicies),
 				addonfactory.GetValuesFromAddonAnnotation,
 				addonfactory.GetAddOnDeploymentConfigValues(
 					afutils.NewAddOnDeploymentConfigGetter(addonClient),

--- a/deploy/managedcluster/addons/install.sh
+++ b/deploy/managedcluster/addons/install.sh
@@ -60,13 +60,20 @@ BASEDDOMAIN=$($KUBECTL get ingress.config.openshift.io cluster -o=jsonpath='{.sp
 # Install cluster-proxy CRDs first
 oc apply -f https://raw.githubusercontent.com/stolostron/cluster-proxy/$OCM_BRANCH/charts/cluster-proxy/crds/managedproxyconfigurations.yaml
 
+# Match injectValuesOverrides() in backplane-operator pkg/rendering/renderer.go.
+# Raw helm install does not run the Go renderer; without these --sets the manager
+# gets --enable-kube-api-proxy= / --enable-service-proxy= (empty bools) and CrashLoopBackOffs.
 ../$HELM install \
 	-n open-cluster-management --create-namespace \
 	cluster-proxy-addon pkg/templates/charts/toggle/cluster-proxy-addon \
   --set global.namespace=open-cluster-management \
 	--set global.pullPolicy=Always \
 	--set global.imageOverrides.cluster_proxy="${IMAGE_CLUSTER_PROXY}:${OCM_BRANCH}" \
-	--set hubconfig.clusterIngressDomain="${BASEDDOMAIN}"
+	--set global.networkPolicies.enabled=true \
+	--set hubconfig.clusterIngressDomain="${BASEDDOMAIN}" \
+	--set enableKubeApiProxy=false \
+	--set enableServiceProxy=true \
+	--set enableImpersonation=true
 if [ $? -eq 1 ]; then
   echo "failed to install cluster-proxy addon"
   exit 1

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -62,13 +62,18 @@ type GlobalValues struct {
 	NodeSelector    map[string]string `json:"nodeSelector,"`
 }
 
-type Values struct {
-	GlobalValues                    GlobalValues `json:"global,omitempty"`
-	EnableSyncLabelsToClusterClaims string       `json:"enableSyncLabelsToClusterClaims"`
-	EnableNodeCapacity              string       `json:"enableNodeCapacity"`
+type NetworkPoliciesValues struct {
+	Enabled bool `json:"enabled"`
 }
 
-func NewGetValuesFunc(imageName string) addonfactory.GetValuesFunc {
+type Values struct {
+	GlobalValues                    GlobalValues          `json:"global,omitempty"`
+	EnableSyncLabelsToClusterClaims string                `json:"enableSyncLabelsToClusterClaims"`
+	EnableNodeCapacity              string                `json:"enableNodeCapacity"`
+	NetworkPolicies                 NetworkPoliciesValues `json:"networkPolicies"`
+}
+
+func NewGetValuesFunc(imageName string, enableNetworkPolicies bool) addonfactory.GetValuesFunc {
 	return func(cluster *clusterv1.ManagedCluster,
 		addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 		overrideName, err := imageregistry.OverrideImageByAnnotation(cluster.GetAnnotations(), imageName)
@@ -95,6 +100,9 @@ func NewGetValuesFunc(imageName string) addonfactory.GetValuesFunc {
 			},
 			EnableSyncLabelsToClusterClaims: enableSyncLabelsToClusterClaims,
 			EnableNodeCapacity:              enableNodeCapacity,
+			NetworkPolicies: NetworkPoliciesValues{
+				Enabled: enableNetworkPolicies,
+			},
 		}
 
 		nodeSelector, err := getNodeSelector(cluster)

--- a/pkg/addon/addon_test.go
+++ b/pkg/addon/addon_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stolostron/cluster-lifecycle-api/imageregistry/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -143,16 +144,22 @@ func newAddonConfigWithResourceRequirement(containerID string, resources v1.Reso
 
 func newAgentAddon(t *testing.T, cluster *clusterv1.ManagedCluster,
 	addonDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig) agent.AgentAddon {
+	return newAgentAddonWithNetworkPolicies(t, cluster, addonDeploymentConfig, false)
+}
+
+func newAgentAddonWithNetworkPolicies(t *testing.T, cluster *clusterv1.ManagedCluster,
+	addonDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig, enableNetworkPolicies bool) agent.AgentAddon {
 	registrationOption := NewRegistrationOption(nil, nil, WorkManagerAddonName)
 
-	scheme := runtime.NewScheme()
-	clusterv1.Install(scheme)
+	agentScheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(agentScheme)
+	clusterv1.Install(agentScheme)
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	client := fake.NewClientBuilder().WithScheme(agentScheme).WithObjects(cluster).Build()
 	getter := newTestConfigGetter(addonDeploymentConfig)
-	getValuesFunc := NewGetValuesFunc(addonImage)
+	getValuesFunc := NewGetValuesFunc(addonImage, enableNetworkPolicies)
 	agentAddon, err := addonfactory.NewAgentAddonFactory(WorkManagerAddonName, ChartFS, ChartDir).
-		WithScheme(scheme).
+		WithScheme(agentScheme).
 		WithGetValuesFuncs(getValuesFunc, addonfactory.GetValuesFromAddonAnnotation,
 			addonfactory.GetAddOnDeploymentConfigValues(
 				getter,
@@ -929,4 +936,46 @@ func TestAddonConfigCustomizedVariableFunc(t *testing.T) {
 
 		})
 	}
+}
+
+func TestWorkManagerNetworkPolicy(t *testing.T) {
+	cluster := newCluster("cluster1", "OpenShift", map[string]string{}, map[string]string{})
+	addon := newAddon("work-manager", "cluster1", "", "")
+
+	t.Run("disabled omits NetworkPolicy", func(t *testing.T) {
+		agentAddon := newAgentAddonWithNetworkPolicies(t, cluster, nil, false)
+		objects, err := agentAddon.Manifests(cluster, addon)
+		if err != nil {
+			t.Fatalf("failed to get manifests: %v", err)
+		}
+		for _, o := range objects {
+			if np, ok := o.(*networkingv1.NetworkPolicy); ok {
+				t.Fatalf("unexpected NetworkPolicy %s when networkPolicies.enabled=false", np.Name)
+			}
+		}
+	})
+
+	t.Run("enabled embeds agent NetworkPolicy", func(t *testing.T) {
+		agentAddon := newAgentAddonWithNetworkPolicies(t, cluster, nil, true)
+		objects, err := agentAddon.Manifests(cluster, addon)
+		if err != nil {
+			t.Fatalf("failed to get manifests: %v", err)
+		}
+		var found *networkingv1.NetworkPolicy
+		for _, o := range objects {
+			if np, ok := o.(*networkingv1.NetworkPolicy); ok {
+				found = np
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("expected work-manager-addon-agent-network-policy when networkPolicies.enabled=true")
+		}
+		if found.Name != "work-manager-addon-agent-network-policy" {
+			t.Errorf("unexpected NetworkPolicy name: %s", found.Name)
+		}
+		if found.Spec.PodSelector.MatchLabels["component"] != "work-manager" {
+			t.Errorf("unexpected podSelector: %v", found.Spec.PodSelector.MatchLabels)
+		}
+	})
 }

--- a/pkg/addon/manifests/chart/templates/networkpolicy.yaml
+++ b/pkg/addon/manifests/chart/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for klusterlet-addon-workmgr (work-manager) on the
+# managed cluster, then allow agent listen ingress and DNS/API egress.
+# Health probes (:8000) are omitted — kubelet probes are not blocked by
+# NetworkPolicy. Peers are port-based (empty "to"/"from") for portability.
+# Gaps: API egress is limited to :443/:6443 (non-standard API ports will
+# fail); DNS is port-only (not openshift-dns namespace-scoped).
+# Enabled when ocm-controller runs with --enable-network-policies=true.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: work-manager-addon-agent-network-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: work-manager
+spec:
+  podSelector:
+    matchLabels:
+      component: work-manager
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # agent listen (--port=4443)
+  - ports:
+    - protocol: TCP
+      port: 4443
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Hub kubeconfig API and spoke kube-apiserver
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/addon/manifests/chart/values.yaml
+++ b/pkg/addon/manifests/chart/values.yaml
@@ -13,6 +13,9 @@ hasRoute: false
 enableSyncLabelsToClusterClaims: true
 enableNodeCapacity: true
 
+networkPolicies:
+  enabled: false
+
 affinity: {}
 
 tolerations:


### PR DESCRIPTION
## Summary
- Add opt-in NetworkPolicy for the work-manager (`klusterlet-addon-workmgr`) addon agent on managed clusters (ACM-37873).
- Gated by `--enable-network-policies` on ocm-controller (default `false`), wired into chart values as `networkPolicies.enabled`.
- Default-deny with agent listen ingress (`:4443`) and DNS/API egress (`53`/`5353`, `443`/`6443`). Health probe ports omitted (kubelet probes are not blocked by NetworkPolicy).

## Test plan
- [x] `go test ./pkg/addon/` (includes `TestWorkManagerNetworkPolicy`)
- [ ] Deploy ocm-controller with `--enable-network-policies=true` and confirm spoke agent NP is applied
- [ ] Confirm agent remains healthy and can reach hub/spoke API + DNS
- [ ] Confirm NP is omitted when the flag is false


Made with [Cursor](https://cursor.com)