### PR TITLE
Filter node heartbeats in ClusterClaim reconciler

### DIFF
--- a/pkg/klusterlet/clusterclaim/clusterclaim_controller.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaim_controller.go
@@ -122,7 +122,7 @@ func (r *clusterClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 func (r *clusterClaimReconciler) syncControlPlaneCreatedClaims(ctx context.Context) error {
-	return syncClaims(ctx, r.clusterClient,
+	return syncClaims(ctx, r.clusterClient, r.clusterClaimLister,
 		r.generateExpectClusterClaims,
 		updateChecks,
 		func() ([]*clusterv1alpha1.ClusterClaim, error) {
@@ -131,7 +131,7 @@ func (r *clusterClaimReconciler) syncControlPlaneCreatedClaims(ctx context.Conte
 }
 
 func (r *clusterClaimReconciler) syncLabelsToClaims(ctx context.Context) error {
-	return syncClaims(ctx, r.clusterClient,
+	return syncClaims(ctx, r.clusterClient, r.clusterClaimLister,
 		func() ([]*clusterv1alpha1.ClusterClaim, error) {
 			return genLabelsToClaims(r.hubClient, r.clusterName)
 		},
@@ -147,6 +147,7 @@ func (r *clusterClaimReconciler) syncLabelsToClaims(ctx context.Context) error {
 // 3. Get existing claims, compare with expected claims, and clean unexpected ones.
 func syncClaims(ctx context.Context,
 	clusterClient clusterclientset.Interface,
+	claimLister clusterv1alpha1lister.ClusterClaimLister,
 	getExpectedClaims func() ([]*clusterv1alpha1.ClusterClaim, error),
 	updatechecks []updateCheck,
 	getExistingClaims func() ([]*clusterv1alpha1.ClusterClaim, error)) error {
@@ -159,7 +160,7 @@ func syncClaims(ctx context.Context,
 	// Create/Update claims.
 	errs := []error{}
 	for _, c := range expectClaims {
-		if err := createOrUpdateClusterClaim(ctx, clusterClient, c, updatechecks); err != nil {
+		if err := createOrUpdateClusterClaim(ctx, clusterClient, claimLister, c, updatechecks); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -272,9 +273,10 @@ var updateChecks = []updateCheck{
 }
 
 func createOrUpdateClusterClaim(ctx context.Context, clusterClient clusterclientset.Interface,
+	claimLister clusterv1alpha1lister.ClusterClaimLister,
 	newClaim *clusterv1alpha1.ClusterClaim,
 	updateChecks []updateCheck) error {
-	oldClaim, err := clusterClient.ClusterV1alpha1().ClusterClaims().Get(ctx, newClaim.Name, metav1.GetOptions{})
+	oldClaim, err := claimLister.Get(newClaim.Name)
 	switch {
 	case errors.IsNotFound(err):
 		_, err := clusterClient.ClusterV1alpha1().ClusterClaims().Create(ctx, newClaim, metav1.CreateOptions{})
@@ -292,8 +294,9 @@ func createOrUpdateClusterClaim(ctx context.Context, clusterClient clusterclient
 				}
 			}
 		}
-		oldClaim.Spec = newClaim.Spec
-		_, err := clusterClient.ClusterV1alpha1().ClusterClaims().Update(ctx, oldClaim, metav1.UpdateOptions{})
+		updated := oldClaim.DeepCopy()
+		updated.Spec = newClaim.Spec
+		_, err := clusterClient.ClusterV1alpha1().ClusterClaims().Update(ctx, updated, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to update ClusterClaim %q: %w", oldClaim.Name, err)
 		}

--- a/pkg/klusterlet/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/klusterlet/clusterclaim/clusterclaim_controller_test.go
@@ -67,11 +67,11 @@ func TestCreateOrUpdate(t *testing.T) {
 				newClusterClaim("x", "y"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 2 {
-					t.Errorf("Expect %d actions, but got: %v", 2, len(actions))
+				if len(actions) != 1 {
+					t.Errorf("Expect %d actions, but got: %v", 1, len(actions))
 				}
-				if actions[1].GetVerb() != "create" {
-					t.Errorf("Expect action create, but got: %s", actions[1].GetVerb())
+				if actions[0].GetVerb() != "create" {
+					t.Errorf("Expect action create, but got: %s", actions[0].GetVerb())
 				}
 			},
 		},
@@ -84,33 +84,40 @@ func TestCreateOrUpdate(t *testing.T) {
 				newClusterClaim("x", "z"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 2 {
-					t.Errorf("Expect 2 actions, but got: %v", len(actions))
+				if len(actions) != 1 {
+					t.Errorf("Expect 1 actions, but got: %v", len(actions))
 				}
-				if actions[1].GetVerb() != "update" {
-					t.Errorf("Expect action update, but got: %s", actions[1].GetVerb())
+				if actions[0].GetVerb() != "update" {
+					t.Errorf("Expect action update, but got: %s", actions[0].GetVerb())
 				}
 			},
 		},
 		{
-			name:    "update cluster claim with create only list with empty",
+			name: "skip update when spec is unchanged",
+			objects: []runtime.Object{
+				newClusterClaim("x", "y"),
+			},
+			clusterclaims: []*clusterv1alpha1.ClusterClaim{
+				newClusterClaim("x", "y"),
+			},
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Errorf("Expect 0 actions, but got %d actions: %v", len(actions), actions)
+				}
+			},
+		},
+		{
+			name:    "create cluster claim with create only list",
 			objects: []runtime.Object{},
 			clusterclaims: []*clusterv1alpha1.ClusterClaim{
 				newClusterClaim(ClaimK8sID, "y"),
-				newClusterClaim(ClaimK8sID, "z"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 3 {
-					t.Errorf("Expect 3 actions, but got %d actions: %v", len(actions), actions)
+				if len(actions) != 1 {
+					t.Errorf("Expect 1 actions, but got %d actions: %v", len(actions), actions)
 				}
-				if actions[0].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
-				}
-				if actions[1].GetVerb() != "create" {
-					t.Errorf("Expect action create, but got: %s", actions[1].GetVerb())
-				}
-				if actions[2].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				if actions[0].GetVerb() != "create" {
+					t.Errorf("Expect action create, but got: %s", actions[0].GetVerb())
 				}
 			},
 		},
@@ -123,11 +130,8 @@ func TestCreateOrUpdate(t *testing.T) {
 				newClusterClaim(ClaimK8sID, "yy"),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Errorf("Expect 1 actions, but got %d actions: %v", len(actions), actions)
-				}
-				if actions[0].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				if len(actions) != 0 {
+					t.Errorf("Expect 0 actions, but got %d actions: %v", len(actions), actions)
 				}
 			},
 		},
@@ -142,15 +146,8 @@ func TestCreateOrUpdate(t *testing.T) {
 				newClusterClaim(ClaimOCMPlatform, PlatformOther),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				// expect 2 'get' actions
-				if len(actions) != 2 {
-					t.Errorf("Expect 2 actions, but got %d actions: %v", len(actions), actions)
-				}
-				if actions[0].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
-				}
-				if actions[1].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				if len(actions) != 0 {
+					t.Errorf("Expect 0 actions, but got %d actions: %v", len(actions), actions)
 				}
 			},
 		},
@@ -165,20 +162,13 @@ func TestCreateOrUpdate(t *testing.T) {
 				newClusterClaim(ClaimOCMPlatform, PlatformAWS),
 			},
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				// expect 4 actions: get update get update
-				if len(actions) != 4 {
-					t.Errorf("Expect 3 actions, but got %d actions: %v", len(actions), actions)
+				if len(actions) != 2 {
+					t.Errorf("Expect 2 actions, but got %d actions: %v", len(actions), actions)
 				}
-				if actions[0].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
+				if actions[0].GetVerb() != "update" {
+					t.Errorf("Expect action update, but got: %s", actions[0].GetVerb())
 				}
 				if actions[1].GetVerb() != "update" {
-					t.Errorf("Expect action update, but got: %s", actions[1].GetVerb())
-				}
-				if actions[2].GetVerb() != "get" {
-					t.Errorf("Expect action get, but got: %s", actions[1].GetVerb())
-				}
-				if actions[3].GetVerb() != "update" {
 					t.Errorf("Expect action update, but got: %s", actions[1].GetVerb())
 				}
 			},
@@ -188,13 +178,24 @@ func TestCreateOrUpdate(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range testcases {
 		clusterClient := clusterfake.NewSimpleClientset(tc.objects...)
+		claimLister := newFakeClusterClaimLister(clusterClaimsFromObjects(tc.objects))
 		for _, cc := range tc.clusterclaims {
-			if err := createOrUpdateClusterClaim(ctx, clusterClient, cc, updateChecks); err != nil {
+			if err := createOrUpdateClusterClaim(ctx, clusterClient, claimLister, cc, updateChecks); err != nil {
 				t.Errorf("%s: unexpected error: %v", tc.name, err)
 			}
 		}
 		tc.validateAddonActions(t, clusterClient.Actions())
 	}
+}
+
+func clusterClaimsFromObjects(objects []runtime.Object) []*clusterv1alpha1.ClusterClaim {
+	claims := make([]*clusterv1alpha1.ClusterClaim, 0, len(objects))
+	for _, obj := range objects {
+		if claim, ok := obj.(*clusterv1alpha1.ClusterClaim); ok {
+			claims = append(claims, claim)
+		}
+	}
+	return claims
 }
 
 var testClusterName = "test-cluster"

--- a/pkg/klusterlet/objectsource/node.go
+++ b/pkg/klusterlet/objectsource/node.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -30,12 +32,14 @@ func NewNodeSource(nodeInformer coreinformers.NodeInformer) source.Source {
 var _ source.SyncingSource = &NodeSource{}
 
 func (s *NodeSource) Start(ctx context.Context, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
-	// all predicates are ignored
 	s.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			s.handler.Create(ctx, event.CreateEvent{}, queue)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
+			if !nodeEventAffectsClusterClaim(oldObj, newObj) {
+				return
+			}
 			s.handler.Update(ctx, event.UpdateEvent{}, queue)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -51,6 +55,46 @@ func (s *NodeSource) WaitForSync(ctx context.Context) error {
 		return fmt.Errorf("never achieved initial sync")
 	}
 	return nil
+}
+
+// nodeEventAffectsClusterClaim reports whether a node update can change
+// schedulable.open-cluster-management.io or related cluster inventory data.
+// Routine kubelet heartbeats and lease refreshes are ignored.
+func nodeEventAffectsClusterClaim(oldObj, newObj interface{}) bool {
+	oldNode, ok := oldObj.(*corev1.Node)
+	if !ok {
+		return true
+	}
+	newNode, ok := newObj.(*corev1.Node)
+	if !ok {
+		return true
+	}
+
+	if oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints) {
+		return true
+	}
+	if !apiequality.Semantic.DeepEqual(oldNode.Status.Capacity, newNode.Status.Capacity) {
+		return true
+	}
+	if nodeConditionStatus(oldNode, corev1.NodeReady) != nodeConditionStatus(newNode, corev1.NodeReady) {
+		return true
+	}
+	if nodeConditionStatus(oldNode, corev1.NodeNetworkUnavailable) != nodeConditionStatus(newNode, corev1.NodeNetworkUnavailable) {
+		return true
+	}
+	return false
+}
+
+func nodeConditionStatus(node *corev1.Node, conditionType corev1.NodeConditionType) corev1.ConditionStatus {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == conditionType {
+			return condition.Status
+		}
+	}
+	return ""
 }
 
 // nodeEventHandler maps any event to an empty request

--- a/pkg/klusterlet/objectsource/node_test.go
+++ b/pkg/klusterlet/objectsource/node_test.go
@@ -1,0 +1,93 @@
+package objectsource
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func readyNode() *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("8"),
+			},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue, LastHeartbeatTime: metav1.Now()},
+			},
+		},
+	}
+}
+
+func TestNodeEventAffectsClusterClaim(t *testing.T) {
+	heartbeatOld := readyNode()
+	heartbeatNew := readyNode()
+	heartbeatNew.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
+
+	unschedulable := readyNode()
+	unschedulable.Spec.Unschedulable = true
+
+	notReady := readyNode()
+	notReady.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	tainted := readyNode()
+	tainted.Spec.Taints = []corev1.Taint{{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoExecute}}
+
+	capacityChanged := readyNode()
+	capacityChanged.Status.Capacity[corev1.ResourceCPU] = resource.MustParse("16")
+
+	tests := []struct {
+		name     string
+		oldObj   interface{}
+		newObj   interface{}
+		expected bool
+	}{
+		{
+			name:     "ignore kubelet heartbeat",
+			oldObj:   heartbeatOld,
+			newObj:   heartbeatNew,
+			expected: false,
+		},
+		{
+			name:     "reconcile unschedulable change",
+			oldObj:   readyNode(),
+			newObj:   unschedulable,
+			expected: true,
+		},
+		{
+			name:     "reconcile ready condition change",
+			oldObj:   readyNode(),
+			newObj:   notReady,
+			expected: true,
+		},
+		{
+			name:     "reconcile taint change",
+			oldObj:   readyNode(),
+			newObj:   tainted,
+			expected: true,
+		},
+		{
+			name:     "reconcile capacity change",
+			oldObj:   readyNode(),
+			newObj:   capacityChanged,
+			expected: true,
+		},
+		{
+			name:     "reconcile unexpected object type",
+			oldObj:   "not-a-node",
+			newObj:   readyNode(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeEventAffectsClusterClaim(tt.oldObj, tt.newObj); got != tt.expected {
+				t.Errorf("nodeEventAffectsClusterClaim() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes ACM-42809: klusterlet-addon-workmgr reconciled ClusterClaims on every kubelet node heartbeat because the Node informer ignored predicates and each reconcile live-GETed every ClusterClaim.
- Ignore heartbeat-only Node updates. Reconcile only when unschedulable, taints, capacity, or Ready/NetworkUnavailable change.
- Read existing ClusterClaims from the informer cache instead of live API GETs, and DeepCopy before update.

Lab note: on ACM 2.17 / 6 nodes, ClusterClaim writes were already skipped when spec was unchanged. The missing predicates and live GETs are still a performance bug on large managed clusters (customer case 04508842).

## Test plan
- [x] go test ./pkg/klusterlet/objectsource ./pkg/klusterlet/clusterclaim
- [ ] Verify schedulable.open-cluster-management.io still updates when a node is cordoned/uncordoned
- [ ] On a managed cluster, confirm node heartbeats no longer enqueue ClusterClaim reconciles / live GETs